### PR TITLE
[feature] ダーク/ライトモード機能の実装

### DIFF
--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -2,7 +2,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import Providers from "./providers"; // インポート
+import Providers from "./providers";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -17,9 +17,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ja" suppressHydrationWarning>
       <body className={inter.className}>
-        <Providers>{children}</Providers> {/* childrenをラップ */}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -3,8 +3,8 @@ import Dashboard from "@/components/Dashboard";
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-black text-white">
-      <h1 className="text-2xl font-bold p-4">Stock Dashboard</h1>
+    <main className="min-h-screen">
+      <h1 className="text-2xl font-bold p-4">KABUKAWA View</h1>
       <Dashboard />
     </main>
   );

--- a/front/app/providers.tsx
+++ b/front/app/providers.tsx
@@ -1,12 +1,17 @@
 // front/app/providers.tsx
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        {children}
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }

--- a/front/components/ChartWidget.tsx
+++ b/front/components/ChartWidget.tsx
@@ -9,11 +9,12 @@ type Props = {
   interval: string;
   label: string;
   chartType: ChartType;
+  theme?: "light" | "dark";
 };
 
 // TradingViewウィジェットを描画するコンポーネント
 const ChartWidget: React.FC<Props> = memo(
-  ({ symbol, interval, label, chartType }) => {
+  ({ symbol, interval, label, chartType, theme = "light" }) => {
     const containerRef = useRef<HTMLDivElement>(null);
     // 安定した一意なIDを生成する
     const widgetId = `tradingview_${symbol.replace(/[:]/g, "_")}`;
@@ -44,7 +45,7 @@ const ChartWidget: React.FC<Props> = memo(
                 symbol: symbol,
                 interval: "D",
                 timezone: "Asia/Tokyo",
-                theme: "dark",
+                theme: theme,
                 style: "3",
                 locale: "ja",
                 enable_publishing: false,
@@ -58,7 +59,7 @@ const ChartWidget: React.FC<Props> = memo(
                 symbol: symbol,
                 interval: interval,
                 timezone: "Asia/Tokyo",
-                theme: "dark",
+                theme: theme,
                 style: "1",
                 locale: "ja",
                 enable_publishing: false,
@@ -80,7 +81,7 @@ const ChartWidget: React.FC<Props> = memo(
         }
       };
       containerRef.current.appendChild(script);
-    }, [symbol, interval, label, chartType, widgetId]); // 依存配列にwidgetIdを追加
+    }, [symbol, interval, label, chartType, widgetId, theme]);
 
     return (
       <div

--- a/front/components/Dashboard.tsx
+++ b/front/components/Dashboard.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTheme } from "next-themes";
 import { Responsive, WidthProvider } from "react-grid-layout";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
@@ -16,6 +17,7 @@ import {
 } from "@/components/ui/select";
 import { ChartType } from "@/types";
 import ChartWidget from "./ChartWidget";
+import ThemeToggleButton from "./ThemeToggleButton";
 
 // グリッドレイアウトの型定義
 type LayoutItem = {
@@ -59,6 +61,7 @@ const presetSymbols = [
 ];
 
 const Dashboard = () => {
+  const { resolvedTheme } = useTheme();
   const queryClient = useQueryClient();
   const [items, setItems] = useState<LayoutItem[]>([]);
   const [interval, setInterval] = useState("D");
@@ -155,7 +158,8 @@ const Dashboard = () => {
             );
           }}
         >
-          <SelectTrigger className="w-[150px] bg-gray-800 border-gray-600 text-white">
+          <SelectTrigger className="w-[150px]">
+            {" "}
             <SelectValue placeholder="スタイルを選択" />
           </SelectTrigger>
           <SelectContent>
@@ -195,7 +199,7 @@ const Dashboard = () => {
             }}
             value={selectedSymbol?.value ?? ""}
           >
-            <SelectTrigger className="w-[220px] bg-gray-800 border-gray-600 text-white">
+            <SelectTrigger className="w-[220px]">
               <SelectValue placeholder="一覧から選択" />
             </SelectTrigger>
             <SelectContent>
@@ -212,10 +216,11 @@ const Dashboard = () => {
         <Button
           onClick={handleSaveLayout}
           variant="outline"
-          className="transition-all duration-200 text-black"
+          className="transition-all duration-200"
         >
           レイアウト保存
         </Button>
+        <ThemeToggleButton />
       </div>
 
       <ResponsiveGridLayout
@@ -243,14 +248,14 @@ const Dashboard = () => {
         {items.map((item) => (
           <div
             key={item.i}
-            className="bg-gray-800 rounded-lg overflow-hidden border border-gray-700 shadow-lg flex flex-col"
+            className="bg-card rounded-lg overflow-hidden border border-border shadow-lg flex flex-col"
           >
-            <div className="drag-handle flex items-center pr-2">
+            <div className="drag-handle flex items-center pr-2 bg-muted/50 text-muted-foreground">
               <span>{item.label}</span>
               <div className="flex-grow" />
               <button
                 onClick={() => handleRemoveChart(item.i)}
-                className="w-6 h-6 flex items-center justify-center rounded-full text-gray-400 hover:bg-gray-600 hover:text-white transition-colors"
+                className="w-6 h-6 flex items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
                 title="チャートを削除"
               >
                 <span className="text-xl font-bold -translate-y-px">
@@ -264,6 +269,7 @@ const Dashboard = () => {
                 interval={interval}
                 label={item.label}
                 chartType={item.chartType}
+                theme={resolvedTheme as "light" | "dark"}
               />
             </div>
           </div>

--- a/front/components/ThemeToggleButton.tsx
+++ b/front/components/ThemeToggleButton.tsx
@@ -1,0 +1,27 @@
+// front/components/ThemeToggleButton.tsx
+"use client";
+
+import * as React from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+
+const ThemeToggleButton = () => {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+    >
+      {/* アイコンの表示をテーマによって切り替え */}
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+};
+
+export default ThemeToggleButton;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -16,6 +16,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.540.0",
         "next": "15.5.0",
+        "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-grid-layout": "^1.5.2",
@@ -7202,6 +7203,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/front/package.json
+++ b/front/package.json
@@ -17,6 +17,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.540.0",
     "next": "15.5.0",
+    "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-grid-layout": "^1.5.2",


### PR DESCRIPTION
【概要】
ダーク/ライトモード機能の実装

【修正内容】
- 従来のダークモードのみのアプリスタイルから、ダークモード/ライトモードを切り替えできるように修正を行った
- `next-themes`を利用し、テーマのアプリ内共有を実現した
- 今回の修正で、「サーバー側とクライアント側でレンダリングされるテキストに差が生じる」可能性が出てきたため、`HTML`タグに`suppressHydrationWarning`を指定した
- `page.tsx`で強制的にダークモードとしていた部分を修正

【参考画像】
<img width="1915" height="568" alt="image" src="https://github.com/user-attachments/assets/1d137960-d4e2-4405-9fab-fcf140ae19d5" />
<img width="1919" height="546" alt="image" src="https://github.com/user-attachments/assets/a5dbc8a7-1db6-4627-9ed0-2e9234e42448" />
