### PR TITLE
[feature] チャートタイプをアイコンを選択することで変更するように修正

### DIFF
--- a/front/components/ChartWidget.tsx
+++ b/front/components/ChartWidget.tsx
@@ -2,11 +2,12 @@
 "use client";
 import React, { useEffect, useRef, memo } from "react";
 
-import { ChartType } from "@/types";
+import { ChartType } from "@/constants/chartTypes";
+import { Interval } from "@/constants/intervals";
 
 type Props = {
   symbol: string;
-  interval: string;
+  interval: Interval;
   label: string;
   chartType: ChartType;
   theme?: "light" | "dark";
@@ -37,47 +38,52 @@ const ChartWidget: React.FC<Props> = memo(
         // スクリプト読み込み後に window.TradingView が存在するか、
         // そしてコンテナがまだ存在するかを再度確認
         if (window.TradingView && containerRef.current) {
+          const baseOptions = {
+            autosize: true,
+            interval: interval,
+            symbol: symbol,
+            timezone: "Asia/Tokyo",
+            theme: theme,
+            locale: "ja",
+            enable_publishing: false,
+            allow_symbol_change: true,
+            container_id: widgetId,
+            // 出来高を非表示にする
+            hide_volume: true,
+            // チャート上部のツールバーを非表示にする
+            hide_top_toolbar: true,
+            // 左側の描画ツールバーを非表示にする
+            // hide_side_toolbar: true,
+            // チャート左上の銘柄情報(OHLCなど)を非表示にする
+            // hide_legend: true,
+            // 下部の日付範囲セレクターを非表示にする
+            // withdateranges: false,
+          };
+
+          let specificOptions = {};
           switch (chartType) {
-            case "overview":
-              new window.TradingView.widget({
-                width: "100%",
-                height: "100%",
-                symbol: symbol,
-                interval: "D",
-                timezone: "Asia/Tokyo",
-                theme: theme,
+            case "line":
+              specificOptions = {
                 style: "3",
-                locale: "ja",
-                enable_publishing: false,
-                container_id: widgetId,
-              });
+              };
               break;
-            case "advanced":
+            case "bars":
+              specificOptions = {
+                style: "0",
+              };
+              break;
+            case "candles":
             default:
-              new window.TradingView.widget({
-                autosize: true,
-                symbol: symbol,
-                interval: interval,
-                timezone: "Asia/Tokyo",
-                theme: theme,
+              specificOptions = {
                 style: "1",
-                locale: "ja",
-                enable_publishing: false,
-                allow_symbol_change: true,
-                container_id: widgetId, // 安定したIDを使用
-                // 出来高を非表示にする
-                hide_volume: true,
-                // チャート上部のツールバーを非表示にする
-                hide_top_toolbar: true,
-                // 左側の描画ツールバーを非表示にする
-                // hide_side_toolbar: true,
-                // チャート左上の銘柄情報(OHLCなど)を非表示にする
-                // hide_legend: true,
-                // 下部の日付範囲セレクターを非表示にする
-                // withdateranges: false,
-              });
+              };
               break;
           }
+
+          new window.TradingView.widget({
+            ...baseOptions,
+            ...specificOptions,
+          });
         }
       };
       containerRef.current.appendChild(script);

--- a/front/components/ui/separator.tsx
+++ b/front/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/front/constants/chartTypes.ts
+++ b/front/constants/chartTypes.ts
@@ -1,0 +1,9 @@
+// front/constants/chartType.ts
+export const chartTypeOptions = [
+  { name: "candles", label: "ローソク足" },
+  { name: "line", label: "ライン" },
+  { name: "bars", label: "バー" },
+] as const;
+
+// データからChartTypeを自動生成する
+export type ChartType = (typeof chartTypeOptions)[number]["name"];

--- a/front/constants/intervals.ts
+++ b/front/constants/intervals.ts
@@ -1,0 +1,11 @@
+// front/constants/intervals.ts
+export const intervalOptions = [
+  { value: "15", label: "15分" },
+  { value: "30", label: "30分" },
+  { value: "60", label: "1時間" },
+  { value: "240", label: "4時間" },
+  { value: "D", label: "日足" },
+  { value: "W", label: "週足" },
+] as const;
+
+export type Interval = (typeof intervalOptions)[number]["value"];

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.85.5",
         "axios": "^1.11.0",
@@ -1902,6 +1903,29 @@
         "@radix-ui/react-visually-hidden": "1.2.3",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/front/package.json
+++ b/front/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.85.5",
     "axios": "^1.11.0",

--- a/front/types/chartType.ts
+++ b/front/types/chartType.ts
@@ -1,2 +1,0 @@
-// front/types/chartType.ts
-export type ChartType = "advanced" | "overview";

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -1,2 +1,1 @@
 // front/types/index.ts
-export * from "./chartType";


### PR DESCRIPTION
### 【概要】
チャートタイプをアイコンを選択することで変更するように修正

### 【修正内容】
- 従来はプルダウンメニューで選択していた`チャートタイプ`を`アイコン`を選択する方式へ変更した
- `chartType`、`interval`を`constants`で定義した（`Types`の定義は廃止）
- 各コンテンツの間にセパレータを設置するようにした
- `Trading view`のスクリプト呼び出し時のオプションで共通項はまとめるように修正を行った

### 【参考画像】
<img width="1919" height="524" alt="image" src="https://github.com/user-attachments/assets/2a4540a3-85f8-4219-a07b-348f9655659e" />
