### PR TITLE
[feature] チャート操作無効時はチャートのどこをつかんでも移動可能とした

### DIFF
--- a/front/components/Dashboard.tsx
+++ b/front/components/Dashboard.tsx
@@ -360,7 +360,7 @@ const Dashboard = () => {
         cols={COLS}
         rowHeight={16}
         onLayoutChange={handleLayoutChange}
-        draggableHandle=".drag-handle"
+        draggableCancel=".chart-area"
         resizeHandles={["s", "w", "e", "n", "sw", "nw", "se", "ne"]}
         compactType="vertical"
         preventCollision={false}
@@ -397,19 +397,23 @@ const Dashboard = () => {
                 </span>
               </button>
             </div>
-            <div
-              className={`flex-grow h-full ${
-                !enableChartOperation ? "pointer-events-none" : ""
-              }`}
-            >
-              <ChartWidget
-                symbol={item.symbol}
-                interval={interval}
-                label={item.label}
-                chartType={chartType}
-                theme={resolvedTheme as "light" | "dark"}
-                options={widgetOptions}
-              />
+            <div className="flex-grow h-full relative">
+              {/* ChartWidget自体は常にドラッグキャンセル領域に配置 */}
+              <div className="chart-area h-full">
+                <ChartWidget
+                  symbol={item.symbol}
+                  interval={interval}
+                  label={item.label}
+                  chartType={chartType}
+                  theme={resolvedTheme as "light" | "dark"}
+                  options={widgetOptions}
+                />
+              </div>
+
+              {/* チャート操作が無効な時だけ、上に透明なオーバーレイを重ねてドラッグ操作を受け付ける */}
+              {!enableChartOperation && (
+                <div className="absolute inset-0 cursor-move" />
+              )}
             </div>
           </div>
         ))}


### PR DESCRIPTION
### 【概要】
チャート操作無効時はチャートのどこをつかんでも移動可能とした

### 【修正内容】
- `ドラッグ可能エリアの指定`方式から`ドラッグ無効エリアの指定`方式に変更を行った
- これにより何も指定しなければすべてドラッグ可能となった
- チャート部分(`ChartWidget`)は常にドラッグ無効エリアと指定
- チャート操作が無効な時だけ、ドラッグ操作を受け付ける`<div>`を設置
- この`<div>`をチャート部分に重ねることで、チャート操作無効時はドラッグで移動可能となった