### PR TITLE
[feature] ヘッダー部分の非表示機能の実装

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -51,5 +51,6 @@ def save_layout(layout: List[ChartItem]):
 
 # 仮想環境の起動方法：
 # .\venv\Scripts\Activate
+# deactivate
 # サーバーの起動方法:
 # ターミナルで `uvicorn main:app --reload` を実行

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -4,7 +4,6 @@ import Dashboard from "@/components/Dashboard";
 export default function Home() {
   return (
     <main className="min-h-screen">
-      <h1 className="text-2xl font-bold p-4">KABUKAWA View</h1>
       <Dashboard />
     </main>
   );

--- a/front/constants/symbols.ts
+++ b/front/constants/symbols.ts
@@ -345,15 +345,15 @@ export const fxSymbols = [
 export const indexSymbols = [
   { label: "日経平均 (Nikkei 225)", value: "NIKKEI225" },
   { label: "TOPIX", value: "TOPIX" },
-  { label: "S&P 500", value: "SP:SPX" },
+  { label: "S&P 500", value: "VANTAGE:SP500" },
   { label: "NASDAQ 100", value: "NASDAQ:NDX" },
-  { label: "ダウ平均 (DJI)", value: "DJ:DJI" },
-  { label: "ラッセル 2000", value: "RUSSELL:RUT" },
+  { label: "ダウ平均 (DJI)", value: "DJI" },
+  { label: "ラッセル 2000", value: "RUSSELL" },
   { label: "ドイツ DAX", value: "XETR:DAX" },
-  { label: "イギリス FTSE 100", value: "TVC:UKX" },
-  { label: "フランス CAC 40", value: "EURONEXT:PX1" },
-  { label: "香港ハンセン指数", value: "HSI:HSI" },
-  { label: "上海総合指数", value: "SSE:000001" },
+  { label: "イギリス FTSE 100", value: "FTSE100" },
+  { label: "フランス CAC 40", value: "CAC40" },
+  { label: "香港ハンセン指数", value: "HSI" },
+  { label: "上海総合指数", value: "950096" },
 ];
 
 // すべての銘柄を結合したリスト（オプション）


### PR DESCRIPTION
### 【概要】
ヘッダー部分の非表示機能の実装

### 【修正内容】
- `page.tsx`で記述していたヘッダーを`Dashboard.tsx`へ移行
- `Dashboard.tsx`で移行したヘッダーとチャートオプションの列を`isHeaderVisible`により表示/非表示の制御を行う
- 表示/非表示切り替えボタンがチャートに被さるため、普段は半透明状態にした

### 【スクリーンショット】
<img width="1919" height="862" alt="image" src="https://github.com/user-attachments/assets/cbd53e0a-57f5-444d-80cf-1463a4fb70cc" />
