### PR TITLE
[feature] 既表示のチャートは銘柄追加で選択不可とする機能の実装

### DIFF
--- a/front/components/Dashboard.tsx
+++ b/front/components/Dashboard.tsx
@@ -1,7 +1,7 @@
 // front/app/components/Dashboard.tsx
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useTheme } from "next-themes";
 import { Responsive, WidthProvider } from "react-grid-layout";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -119,6 +119,8 @@ const Dashboard = () => {
     queryKey: ["layout"],
     queryFn: fetchLayout,
   });
+
+  const addedSymbols = useMemo(() => items.map((item) => item.symbol), [items]);
 
   useEffect(() => {
     if (initialLayout) {
@@ -478,6 +480,7 @@ const Dashboard = () => {
         isOpen={isSearchModalOpen}
         onClose={() => setIsSearchModalOpen(false)}
         onAdd={handleAddMultipleCharts}
+        addedSymbols={addedSymbols}
       />
     </div>
   );

--- a/front/components/SymbolSearchModal.tsx
+++ b/front/components/SymbolSearchModal.tsx
@@ -27,17 +27,23 @@ type Props = {
   isOpen: boolean;
   onClose: () => void;
   onAdd: (symbols: Symbol[]) => void;
+  addedSymbols: string[];
 };
 
 const TABS = {
   japan: { label: "日本株", data: nikkei225Symbols },
   us: { label: "米国株", data: usStockSymbols },
-  index: { label: "指数", data: indexSymbols },
+  index: { label: "インデックス", data: indexSymbols },
   fx: { label: "FX", data: fxSymbols },
 };
 type TabKey = keyof typeof TABS;
 
-export const SymbolSearchModal = ({ isOpen, onClose, onAdd }: Props) => {
+export const SymbolSearchModal = ({
+  isOpen,
+  onClose,
+  onAdd,
+  addedSymbols,
+}: Props) => {
   const [activeTab, setActiveTab] = useState<TabKey>("japan");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedSymbols, setSelectedSymbols] = useState<Symbol[]>([]);
@@ -55,6 +61,11 @@ export const SymbolSearchModal = ({ isOpen, onClose, onAdd }: Props) => {
   }, [activeTab, searchQuery]);
 
   const handleSelectSymbol = (symbol: Symbol) => {
+    // 既にダッシュボードに追加されているシンボルは選択不可にする
+    if (addedSymbols.includes(symbol.value)) {
+      return;
+    }
+
     setSelectedSymbols((prev) =>
       prev.some((s) => s.value === symbol.value)
         ? prev.filter((s) => s.value !== symbol.value)
@@ -133,7 +144,7 @@ export const SymbolSearchModal = ({ isOpen, onClose, onAdd }: Props) => {
               onValueChange={(value) => setActiveTab(value as TabKey)}
               className="flex flex-col flex-grow min-h-0"
             >
-              <TabsList>
+              <TabsList className="gap-3">
                 {Object.entries(TABS).map(([key, { label }]) => (
                   <TabsTrigger key={key} value={key}>
                     {label}
@@ -147,13 +158,16 @@ export const SymbolSearchModal = ({ isOpen, onClose, onAdd }: Props) => {
                     const isSelected = selectedSymbols.some(
                       (s) => s.value === symbol.value
                     );
+                    const isAlreadyAdded = addedSymbols.includes(symbol.value);
                     return (
                       <div
                         key={symbol.value}
                         onClick={() => handleSelectSymbol(symbol)}
-                        className={`flex items-center gap-4 p-2 pr-4 rounded-md cursor-pointer hover:bg-muted ${
-                          isSelected ? "bg-muted font-semibold" : ""
-                        }`}
+                        className={`flex items-center gap-4 p-2 pr-4 rounded-md ${
+                          isAlreadyAdded
+                            ? "opacity-50 cursor-not-allowed"
+                            : "cursor-pointer hover:bg-muted"
+                        } ${isSelected ? "bg-muted font-semibold" : ""}`}
                       >
                         <span className="w-20 text-sm text-muted-foreground">
                           {symbol.value.split(":").pop()}
@@ -161,6 +175,9 @@ export const SymbolSearchModal = ({ isOpen, onClose, onAdd }: Props) => {
                         <span className="flex-grow truncate">
                           {symbol.label}
                         </span>
+                        {isAlreadyAdded && (
+                          <Badge variant="secondary">追加済み</Badge>
+                        )}
                       </div>
                     );
                   })}


### PR DESCRIPTION
### 【概要】
既表示のチャートは銘柄追加で選択不可とした

### 【修正内容】
- 現在表示中のチャート情報(`addedSymbols`)を、銘柄追加モーダル(`SymbolSearchModal.tsx`)に渡すように修正
- 受け取ったチャート情報を選択出来ないように制御を行う

### 【スクリーンショット】
<img width="1135" height="795" alt="image" src="https://github.com/user-attachments/assets/a253e908-b7d2-4534-b5bb-e6f75428059e" />
