### PR TITLE
[refactor] 肥大化したDashboardのリファクタリング

### DIFF
--- a/front/components/ChartGrid.tsx
+++ b/front/components/ChartGrid.tsx
@@ -1,0 +1,95 @@
+// front/components/ChartGrid.tsx
+import { useState } from "react";
+import { Responsive, WidthProvider } from "react-grid-layout";
+import ChartWidget from "./ChartWidget";
+import { LayoutItem } from "@/types";
+import { COLS } from "@/constants/cols";
+import { Interval } from "@/constants/intervals";
+import { ChartType } from "@/constants/chartTypes";
+import { TradingViewOptions } from "@/types";
+
+type Props = {
+  items: LayoutItem[];
+  onLayoutChange: (layout: ReactGridLayout.Layout[]) => void;
+  onRemoveChart: (itemId: string) => void;
+  interval: Interval;
+  chartType: ChartType;
+  theme: "light" | "dark";
+  widgetOptions: TradingViewOptions;
+  enableChartOperation: boolean;
+};
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+const ChartGrid = ({
+  items,
+  onLayoutChange,
+  onRemoveChart,
+  interval,
+  chartType,
+  theme,
+  widgetOptions,
+  enableChartOperation,
+}: Props) => {
+  const [isDragging, setIsDragging] = useState(false);
+  return (
+    <ResponsiveGridLayout
+      className={`layout ${isDragging ? "dragging" : ""}`}
+      cols={COLS}
+      rowHeight={16}
+      onLayoutChange={onLayoutChange}
+      draggableCancel=".chart-area"
+      resizeHandles={["s", "w", "e", "n", "sw", "nw", "se", "ne"]}
+      compactType="vertical"
+      preventCollision={false}
+      onDragStart={() => setIsDragging(true)}
+      onDragStop={() => setIsDragging(false)}
+      onResizeStart={() => setIsDragging(true)}
+      onResizeStop={() => setIsDragging(false)}
+      margin={[0, 0]}
+      containerPadding={[0, 0]}
+    >
+      {items.map((item) => (
+        <div
+          key={item.i}
+          data-grid={{
+            i: item.i,
+            x: item.x,
+            y: item.y,
+            w: item.w,
+            h: item.h,
+          }}
+          className="bg-card rounded-lg overflow-hidden border border-border shadow-lg flex flex-col"
+        >
+          <div className="drag-handle flex items-center pr-2 bg-muted/50 text-muted-foreground">
+            <span className="flex-1 min-w-0 truncate">{item.label}</span>
+            <button
+              onClick={() => onRemoveChart(item.i)}
+              className="w-6 h-6 flex items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+              title="チャートを削除"
+            >
+              <span className="text-xl font-bold -translate-y-px">&times;</span>
+            </button>
+          </div>
+          <div className="flex-grow h-full relative">
+            <div className="chart-area h-full">
+              <ChartWidget
+                symbol={item.symbol}
+                interval={interval}
+                label={item.label}
+                chartType={chartType}
+                theme={theme}
+                options={widgetOptions}
+              />
+            </div>
+            {!enableChartOperation && (
+              <div className="absolute inset-0 cursor-move" />
+            )}
+          </div>
+        </div>
+      ))}
+    </ResponsiveGridLayout>
+  );
+};
+
+export default ChartGrid;

--- a/front/components/Dashboard.tsx
+++ b/front/components/Dashboard.tsx
@@ -1,484 +1,107 @@
 // front/app/components/Dashboard.tsx
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState } from "react";
 import { useTheme } from "next-themes";
-import { Responsive, WidthProvider } from "react-grid-layout";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import axios from "axios";
-import {
-  CandlestickChart,
-  LineChart,
-  BarChart4,
-  Settings,
-  Search,
-  ChevronUp,
-  ChevronDown,
-} from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
-import { chartTypeOptions, ChartType } from "@/constants/chartTypes";
-import { intervalOptions, Interval } from "@/constants/intervals";
-import { AllChartSettings, TradingViewOptions } from "@/types/ChartOptions";
-import ChartWidget from "./ChartWidget";
-import ThemeToggleButton from "./ThemeToggleButton";
+import { AllChartSettings, Symbol } from "@/types";
 import { ChartSettingsModal } from "./ChartSettingsModal";
-import { Symbol } from "@/types/Symbol";
 import { SymbolSearchModal } from "./SymbolSearchModal";
-
-// グリッドレイアウトの型定義
-type LayoutItem = {
-  i: string;
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-  symbol: string;
-  label: string;
-};
-
-const ResponsiveGridLayout = WidthProvider(Responsive);
-
-// APIから取得/APIへ送信するデータの型
-type LayoutData = LayoutItem[];
-
-// --- API通信の関数 ---
-const fetchLayout = async (): Promise<LayoutData> => {
-  const { data } = await axios.get("http://localhost:8000/api/layout");
-  return data;
-};
-
-const saveLayout = async (layout: LayoutData): Promise<void> => {
-  await axios.post("http://localhost:8000/api/layout", layout);
-};
-
-const presetSymbols = [
-  { label: "日経平均 (Nikkei 225)", value: "NIKKEI225" },
-  { label: "TOPIX", value: "TOPIX" },
-  { label: "トヨタ自動車", value: "TRADU:7203" },
-  { label: "ソニーグループ", value: "TRADU:6758" },
-  { label: "ソフトバンクグループ", value: "TRADU:9984" },
-  { label: "S&P 500", value: "VANTAGE:SP500" },
-  { label: "NASDAQ 100", value: "NASDAQ:NDX" },
-  { label: "Apple", value: "NASDAQ:AAPL" },
-  { label: "Microsoft", value: "NASDAQ:MSFT" },
-  { label: "ドル/円 (USD/JPY)", value: "FX:USDJPY" },
-  { label: "ユーロ/ドル (EUR/USD)", value: "FX:EURUSD" },
-  { label: "ダウ平均 (DJI)", value: "DJI" },
-];
-
-const iconMap: Record<ChartType, React.ElementType> = {
-  candles: CandlestickChart,
-  line: LineChart,
-  bars: BarChart4,
-};
-
-const COLS = { lg: 72, md: 60, sm: 36, xs: 24, xxs: 12 };
+import DashboardHeader from "./DashboardHeader";
+import ChartGrid from "./ChartGrid";
+import { HeaderToggleButton } from "./HeaderToggleButton";
+import { useLayout } from "@/hooks/useLayout";
+import { useChartSettings } from "@/hooks/useChartSettings";
+import { useDashboardModals } from "@/hooks/useDashboardModals";
 
 const Dashboard = () => {
   const { resolvedTheme } = useTheme();
-  const queryClient = useQueryClient();
-  const [items, setItems] = useState<LayoutItem[]>([]);
-  const [interval, setInterval] = useState<Interval>("30");
-  // ドラッグ/リサイズ中かどうかの状態を管理
-  const [isDragging, setIsDragging] = useState(false);
-  // 選択された銘柄情報を管理
-  const [selectedSymbol, setSelectedSymbol] = useState<{
-    label: string;
-    value: string;
-  } | null>(null);
-  // チャートのスタイルを管理
-  const [chartType, setChartType] = useState<ChartType>("candles");
-  // モーダルの開閉状態を管理
-  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
-  // チャートオプションの状態を管理
-  const [widgetOptions, setWidgetOptions] = useState<TradingViewOptions>({
-    hide_top_toolbar: true,
-    hide_side_toolbar: true,
-    hide_legend: false,
-    hide_volume: false,
-    withdateranges: false,
-  });
-  const [enableChartOperation, setEnableChartOperation] = useState(false);
-  // 検索モーダルの開閉状態を管理
-  const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
-  // デフォルトのチャートサイズを管理
-  const [defaultChartSize, setDefaultChartSize] = useState({ w: 24, h: 18 });
-  // ヘッダーの表示状態を管理
   const [isHeaderVisible, setIsHeaderVisible] = useState(true);
 
-  const { data: initialLayout, isLoading } = useQuery({
-    queryKey: ["layout"],
-    queryFn: fetchLayout,
-  });
+  const {
+    items,
+    // setItems,
+    isLoading,
+    addedSymbols,
+    handleLayoutChange,
+    saveLayout,
+    addMultipleCharts,
+    removeChart,
+  } = useLayout();
 
-  const addedSymbols = useMemo(() => items.map((item) => item.symbol), [items]);
+  const {
+    chartSettings,
+    setChartSettings,
+    interval,
+    setInterval,
+    chartType,
+    setChartType,
+    widgetOptions,
+    enableChartOperation,
+    defaultChartSize,
+  } = useChartSettings();
 
-  useEffect(() => {
-    if (initialLayout) {
-      setItems(initialLayout);
-    }
-  }, [initialLayout]);
+  const {
+    isSettingsModalOpen,
+    isSearchModalOpen,
+    openSettingsModal,
+    closeSettingsModal,
+    openSearchModal,
+    closeSearchModal,
+  } = useDashboardModals();
 
-  const mutation = useMutation({
-    mutationFn: saveLayout,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["layout"] });
-      console.log("Layout saved!");
-    },
-  });
-
-  const findNextAvailablePosition = useCallback(
-    (
-      layout: LayoutItem[],
-      itemWidth: number,
-      itemHeight: number
-    ): { x: number; y: number } => {
-      const cols = COLS.lg; // 最大のcolsを基準に計算
-      let maxY = 0;
-      layout.forEach((item) => {
-        maxY = Math.max(maxY, item.y + item.h);
-      });
-
-      // グリッドを上から順にチェック
-      for (let y = 0; y < maxY + itemHeight; y++) {
-        for (let x = 0; x <= cols - itemWidth; x++) {
-          let isSpaceAvailable = true;
-          // 新しいアイテムが既存のアイテムと重ならないかチェック
-          for (const item of layout) {
-            if (
-              x < item.x + item.w &&
-              x + itemWidth > item.x &&
-              y < item.y + item.h &&
-              y + itemHeight > item.y
-            ) {
-              isSpaceAvailable = false;
-              break;
-            }
-          }
-          if (isSpaceAvailable) {
-            return { x, y };
-          }
-        }
-      }
-
-      // 空きスペースが見つからなければ最下部に配置
-      return { x: 0, y: maxY };
-    },
-    []
-  );
-
-  const handleLayoutChange = (newLayout: ReactGridLayout.Layout[]) => {
-    setItems((currentItems) => {
-      const layoutMap = new Map(newLayout.map((l) => [l.i, l]));
-      return currentItems.map((item) => {
-        const layoutUpdate = layoutMap.get(item.i);
-        if (layoutUpdate) {
-          return {
-            ...item,
-            x: layoutUpdate.x,
-            y: layoutUpdate.y,
-            w: layoutUpdate.w,
-            h: layoutUpdate.h,
-          };
-        }
-        return item;
-      });
-    });
+  const handleSaveSettings = (newSettings: AllChartSettings) => {
+    setChartSettings(newSettings);
+    closeSettingsModal();
   };
 
-  const handleSaveLayout = () => {
-    mutation.mutate(items);
-  };
-
-  const handleAddChart = () => {
-    if (!selectedSymbol) return;
-    const { w, h } = defaultChartSize;
-    const { x, y } = findNextAvailablePosition(items, w, h);
-
-    const newItem: LayoutItem = {
-      i: `item_${new Date().getTime()}`,
-      x,
-      y,
-      w,
-      h,
-      symbol: selectedSymbol.value,
-      label: selectedSymbol.label,
-    };
-
-    setItems([...items, newItem]);
-    setSelectedSymbol(null);
-  };
-
-  const handleRemoveChart = (itemIdToRemove: string) => {
-    setItems(items.filter((item) => item.i !== itemIdToRemove));
-  };
-
-  const handleSaveSettings = (newOptions: AllChartSettings) => {
-    const { enable_chart_operation, default_w, default_h, ...restOptions } =
-      newOptions;
-
-    if (JSON.stringify(widgetOptions) !== JSON.stringify(restOptions)) {
-      setWidgetOptions(restOptions);
-    }
-    setEnableChartOperation(!!enable_chart_operation);
-    // デフォルトサイズを更新
-    if (default_w && default_h) {
-      setDefaultChartSize({ w: default_w, h: default_h });
-    }
-    setIsSettingsModalOpen(false);
-  };
-
-  // 複数の銘柄を一度に追加するためのハンドラ
   const handleAddMultipleCharts = (symbols: Symbol[]) => {
-    // 既存のアイテムのコピーを作成し、これを基準に新しいアイテムの配置を計算する
-    const layoutForPlacement = [...items];
-
-    const newItems = symbols.map((symbol) => {
-      const { w, h } = defaultChartSize;
-      // 常に最新のレイアウト状況を渡して、次の配置場所を見つける
-      const { x, y } = findNextAvailablePosition(layoutForPlacement, w, h);
-
-      const newItem: LayoutItem = {
-        i: `${symbol.value}_${new Date().getTime()}_${Math.random()}`,
-        x,
-        y,
-        w,
-        h,
-        symbol: symbol.value,
-        label: symbol.label,
-      };
-
-      // 次のアイテムの配置計算のために、作成したアイテムを仮のレイアウトに追加する
-      layoutForPlacement.push(newItem);
-
-      return newItem;
-    });
-
-    // 最後に、既存のアイテムと新しく作成したすべてのアイテムを結合してstateを更新する
-    setItems((prevItems) => [...prevItems, ...newItems]);
+    addMultipleCharts(symbols, defaultChartSize);
   };
 
   if (isLoading) return <div className="text-center p-10">Loading...</div>;
 
   return (
     <div className="h-screen flex flex-col bg-background">
-      <div
-        className={`transition-all duration-300 ease-in-out shrink-0 ${
-          isHeaderVisible ? "auto" : "h-0"
-        }`}
-      >
-        <div
-          className={`p-4 space-y-4 transition-opacity duration-300 overflow-hidden ${
-            isHeaderVisible ? "opacity-100" : "opacity-0"
-          }`}
-        >
-          {/* Row 1: Title and main actions */}
-          <div className="flex justify-between items-center">
-            <div className="flex items-center gap-2">
-              <h1 className="text-2xl font-bold">KABUKAWA View</h1>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button
-                onClick={handleSaveLayout}
-                variant="outline"
-                className="transition-all duration-200"
-              >
-                レイアウト保存
-              </Button>
-              <ThemeToggleButton />
-            </div>
-          </div>
-          {/* Row 2: Chart controls */}
-          <div className="flex items-center gap-2 flex-wrap">
-            <div className="flex items-center gap-1">
-              {chartTypeOptions.map((option) => {
-                const IconComponent = iconMap[option.name];
-                return (
-                  <Button
-                    key={option.name}
-                    variant={
-                      chartType === option.name ? "default" : "secondary"
-                    }
-                    size="icon"
-                    onClick={() => setChartType(option.name)}
-                    title={option.label}
-                  >
-                    <IconComponent className="h-4 w-4" />
-                  </Button>
-                );
-              })}
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={() => setIsSettingsModalOpen(true)}
-                title="チャート設定"
-              >
-                <Settings className="h-4 w-4" />
-              </Button>
-            </div>
-            <Separator orientation="vertical" />
-            {/* グループ2: 時間足 */}
-            <div className="flex items-center gap-1">
-              {intervalOptions.map((option) => (
-                <Button
-                  key={option.value}
-                  onClick={() => setInterval(option.value)}
-                  // 現在選択中の時間足と一致する場合のスタイルを追加
-                  variant={interval === option.value ? "default" : "secondary"}
-                  className="transition-all duration-200"
-                >
-                  {option.label}
-                </Button>
-              ))}
-            </div>
-            <Separator orientation="vertical" />
-            {/* グループ3: 銘柄追加のプルダウンメニュー */}
-            <div className="ml-4 flex items-center gap-2">
-              <Button onClick={() => setIsSearchModalOpen(true)}>
-                <Search className="mr-2 h-4 w-4" />
-                銘柄を追加
-              </Button>
-            </div>
-            <div className="flex items-center gap-2">
-              <Select
-                onValueChange={(value) => {
-                  const selected = presetSymbols.find((s) => s.value === value);
-                  if (selected) {
-                    setSelectedSymbol(selected);
-                  }
-                }}
-                value={selectedSymbol?.value ?? ""}
-              >
-                <SelectTrigger className="w-[220px]">
-                  <SelectValue placeholder="一覧から選択" />
-                </SelectTrigger>
-                <SelectContent>
-                  {presetSymbols.map((symbol) => (
-                    <SelectItem key={symbol.value} value={symbol.value}>
-                      {symbol.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Button onClick={handleAddChart}>追加</Button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <DashboardHeader
+        isVisible={isHeaderVisible}
+        interval={interval}
+        setInterval={setInterval}
+        chartType={chartType}
+        setChartType={setChartType}
+        openSettingsModal={openSettingsModal}
+        openSearchModal={openSearchModal}
+        saveLayout={saveLayout}
+      />
 
       <div className="flex-grow relative">
-        {isHeaderVisible ? (
-          <Button
-            onClick={() => setIsHeaderVisible(false)}
-            className="absolute top-2 left-2 z-50 opacity-50 hover:opacity-100 transition-opacity duration-200"
-            size="icon"
-            variant="outline"
-            title="ヘッダーを非表示"
-          >
-            <ChevronUp className="h-5 w-5" />
-          </Button>
-        ) : (
-          <Button
-            onClick={() => setIsHeaderVisible(true)}
-            className="absolute top-2 left-2 z-50 opacity-50 hover:opacity-100 transition-opacity duration-200"
-            size="icon"
-            variant="outline"
-            title="ヘッダーを表示"
-          >
-            <ChevronDown className="h-5 w-5" />
-          </Button>
-        )}
+        <HeaderToggleButton
+          isVisible={isHeaderVisible}
+          setIsVisible={setIsHeaderVisible}
+        />
         <div className="absolute inset-0">
-          <ResponsiveGridLayout
-            // isDragging状態に応じてクラスを動的に追加
-            className={`layout ${isDragging ? "dragging" : ""}`}
-            cols={COLS}
-            rowHeight={16}
+          <ChartGrid
+            items={items}
             onLayoutChange={handleLayoutChange}
-            draggableCancel=".chart-area"
-            resizeHandles={["s", "w", "e", "n", "sw", "nw", "se", "ne"]}
-            compactType="vertical"
-            preventCollision={false}
-            // ドラッグ/リサイズ開始/終了時にisDragging状態を更新
-            onDragStart={() => setIsDragging(true)}
-            onDragStop={() => setIsDragging(false)}
-            onResizeStart={() => setIsDragging(true)}
-            onResizeStop={() => setIsDragging(false)}
-            // アイテム間のマージンとコンテナのパディングを0に設定
-            margin={[0, 0]}
-            containerPadding={[0, 0]}
-          >
-            {items.map((item) => (
-              <div
-                key={item.i}
-                data-grid={{
-                  i: item.i,
-                  x: item.x,
-                  y: item.y,
-                  w: item.w,
-                  h: item.h,
-                }}
-                className="bg-card rounded-lg overflow-hidden border border-border shadow-lg flex flex-col"
-              >
-                <div className="drag-handle flex items-center pr-2 bg-muted/50 text-muted-foreground">
-                  <span className="flex-1 min-w-0 truncate">{item.label}</span>
-                  <button
-                    onClick={() => handleRemoveChart(item.i)}
-                    className="w-6 h-6 flex items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
-                    title="チャートを削除"
-                  >
-                    <span className="text-xl font-bold -translate-y-px">
-                      &times;
-                    </span>
-                  </button>
-                </div>
-                <div className="flex-grow h-full relative">
-                  {/* ChartWidget自体は常にドラッグキャンセル領域に配置 */}
-                  <div className="chart-area h-full">
-                    <ChartWidget
-                      symbol={item.symbol}
-                      interval={interval}
-                      label={item.label}
-                      chartType={chartType}
-                      theme={resolvedTheme as "light" | "dark"}
-                      options={widgetOptions}
-                    />
-                  </div>
-
-                  {/* チャート操作が無効な時だけ、上に透明なオーバーレイを重ねてドラッグ操作を受け付ける */}
-                  {!enableChartOperation && (
-                    <div className="absolute inset-0 cursor-move" />
-                  )}
-                </div>
-              </div>
-            ))}
-          </ResponsiveGridLayout>
+            onRemoveChart={removeChart}
+            interval={interval}
+            chartType={chartType}
+            theme={resolvedTheme as "light" | "dark"}
+            widgetOptions={widgetOptions}
+            enableChartOperation={enableChartOperation}
+          />
         </div>
       </div>
-      {/* --- モーダルコンポーネントを描画 --- */}
+
       <ChartSettingsModal
         isOpen={isSettingsModalOpen}
-        onClose={() => setIsSettingsModalOpen(false)}
-        options={{
-          ...widgetOptions,
-          enable_chart_operation: enableChartOperation,
-          default_w: defaultChartSize.w,
-          default_h: defaultChartSize.h,
-        }}
+        onClose={closeSettingsModal}
+        options={chartSettings}
         onSave={handleSaveSettings}
       />
       <SymbolSearchModal
         isOpen={isSearchModalOpen}
-        onClose={() => setIsSearchModalOpen(false)}
+        onClose={closeSearchModal}
         onAdd={handleAddMultipleCharts}
         addedSymbols={addedSymbols}
       />

--- a/front/components/DashboardHeader.tsx
+++ b/front/components/DashboardHeader.tsx
@@ -1,0 +1,116 @@
+// front/components/DashboardHeader.tsx
+import {
+  CandlestickChart,
+  LineChart,
+  BarChart4,
+  Settings,
+  Search,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import ThemeToggleButton from "./ThemeToggleButton";
+import { chartTypeOptions, ChartType } from "@/constants/chartTypes";
+import { intervalOptions, Interval } from "@/constants/intervals";
+
+type Props = {
+  isVisible: boolean;
+  interval: Interval;
+  setInterval: (interval: Interval) => void;
+  chartType: ChartType;
+  setChartType: (type: ChartType) => void;
+  openSettingsModal: () => void;
+  openSearchModal: () => void;
+  saveLayout: () => void;
+};
+
+const iconMap: Record<ChartType, React.ElementType> = {
+  candles: CandlestickChart,
+  line: LineChart,
+  bars: BarChart4,
+};
+
+const DashboardHeader = ({
+  isVisible,
+  interval,
+  setInterval,
+  chartType,
+  setChartType,
+  openSettingsModal,
+  openSearchModal,
+  saveLayout,
+}: Props) => {
+  return (
+    <div
+      className={`transition-all duration-300 ease-in-out shrink-0 ${
+        isVisible ? "auto" : "h-0"
+      }`}
+    >
+      <div
+        className={`p-4 space-y-4 transition-opacity duration-300 overflow-hidden ${
+          isVisible ? "opacity-100" : "opacity-0"
+        }`}
+      >
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold">KABUKAWA View</h1>
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={saveLayout}
+              variant="outline"
+              className="transition-all duration-200"
+            >
+              レイアウト保存
+            </Button>
+            <ThemeToggleButton />
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <div className="flex items-center gap-1">
+            {chartTypeOptions.map((option) => {
+              const IconComponent = iconMap[option.name];
+              return (
+                <Button
+                  key={option.name}
+                  variant={chartType === option.name ? "default" : "secondary"}
+                  size="icon"
+                  onClick={() => setChartType(option.name)}
+                  title={option.label}
+                >
+                  <IconComponent className="h-4 w-4" />
+                </Button>
+              );
+            })}
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={openSettingsModal}
+              title="チャート設定"
+            >
+              <Settings className="h-4 w-4" />
+            </Button>
+          </div>
+          <Separator orientation="vertical" />
+          <div className="flex items-center gap-1">
+            {intervalOptions.map((option) => (
+              <Button
+                key={option.value}
+                onClick={() => setInterval(option.value)}
+                variant={interval === option.value ? "default" : "secondary"}
+                className="transition-all duration-200"
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+          <Separator orientation="vertical" />
+          <div className="ml-4 flex items-center gap-2">
+            <Button onClick={openSearchModal}>
+              <Search className="mr-2 h-4 w-4" />
+              銘柄を追加
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default DashboardHeader;

--- a/front/components/HeaderToggleButton.tsx
+++ b/front/components/HeaderToggleButton.tsx
@@ -1,0 +1,32 @@
+// front/components/HeaderToggleButton.tsx
+import { ChevronUp, ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  isVisible: boolean;
+  setIsVisible: (isVisible: boolean) => void;
+};
+
+export const HeaderToggleButton = ({ isVisible, setIsVisible }: Props) => {
+  return isVisible ? (
+    <Button
+      onClick={() => setIsVisible(false)}
+      className="absolute top-2 left-2 z-50 opacity-50 hover:opacity-100 transition-opacity duration-200"
+      size="icon"
+      variant="outline"
+      title="ヘッダーを非表示"
+    >
+      <ChevronUp className="h-5 w-5" />
+    </Button>
+  ) : (
+    <Button
+      onClick={() => setIsVisible(true)}
+      className="absolute top-2 left-2 z-50 opacity-50 hover:opacity-100 transition-opacity duration-200"
+      size="icon"
+      variant="outline"
+      title="ヘッダーを表示"
+    >
+      <ChevronDown className="h-5 w-5" />
+    </Button>
+  );
+};

--- a/front/constants/cols.ts
+++ b/front/constants/cols.ts
@@ -1,0 +1,2 @@
+// front/constants/cols.ts
+export const COLS = { lg: 72, md: 60, sm: 36, xs: 24, xxs: 12 };

--- a/front/constants/symbols.ts
+++ b/front/constants/symbols.ts
@@ -344,7 +344,7 @@ export const fxSymbols = [
 // インデックス
 export const indexSymbols = [
   { label: "日経平均 (Nikkei 225)", value: "NIKKEI225" },
-  { label: "TOPIX", value: "TOPIX" },
+  { label: "TOPIX", value: "IG:TOPIX" },
   { label: "S&P 500", value: "VANTAGE:SP500" },
   { label: "NASDAQ 100", value: "NASDAQ:NDX" },
   { label: "ダウ平均 (DJI)", value: "DJI" },

--- a/front/hooks/useChartSettings.ts
+++ b/front/hooks/useChartSettings.ts
@@ -1,0 +1,48 @@
+// front/hooks/useChartSettings.ts
+import { useState, useMemo } from "react";
+import { Interval } from "@/constants/intervals";
+import { ChartType } from "@/constants/chartTypes";
+import { AllChartSettings, TradingViewOptions } from "@/types";
+
+export const useChartSettings = () => {
+  const [interval, setInterval] = useState<Interval>("30");
+  const [chartType, setChartType] = useState<ChartType>("candles");
+  const [chartSettings, setChartSettings] = useState<AllChartSettings>({
+    hide_top_toolbar: true,
+    hide_side_toolbar: true,
+    hide_legend: false,
+    hide_volume: false,
+    withdateranges: false,
+    enable_chart_operation: false,
+    default_w: 24,
+    default_h: 18,
+  });
+
+  // TradingViewウィジェットに渡すオプションをメモ化
+  const widgetOptions: TradingViewOptions = useMemo(() => {
+    const { enable_chart_operation, default_w, default_h, ...rest } =
+      chartSettings;
+    return rest;
+  }, [chartSettings]);
+
+  const enableChartOperation = chartSettings.enable_chart_operation;
+  const defaultChartSize = useMemo(
+    () => ({
+      w: chartSettings.default_w || 24,
+      h: chartSettings.default_h || 18,
+    }),
+    [chartSettings.default_w, chartSettings.default_h]
+  );
+
+  return {
+    interval,
+    setInterval,
+    chartType,
+    setChartType,
+    widgetOptions,
+    enableChartOperation,
+    defaultChartSize,
+    chartSettings,
+    setChartSettings,
+  };
+};

--- a/front/hooks/useDashboardModals.ts
+++ b/front/hooks/useDashboardModals.ts
@@ -1,0 +1,16 @@
+// front/hooks/useDashboardModals.ts
+import { useState } from "react";
+
+export const useDashboardModals = () => {
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
+
+  return {
+    isSettingsModalOpen,
+    isSearchModalOpen,
+    openSettingsModal: () => setIsSettingsModalOpen(true),
+    closeSettingsModal: () => setIsSettingsModalOpen(false),
+    openSearchModal: () => setIsSearchModalOpen(true),
+    closeSearchModal: () => setIsSearchModalOpen(false),
+  };
+};

--- a/front/hooks/useLayout.ts
+++ b/front/hooks/useLayout.ts
@@ -1,0 +1,144 @@
+// front/hooks/useLayout.ts
+// hooks/useLayout.ts
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { Layout } from "react-grid-layout";
+import { LayoutItem, Symbol } from "@/types";
+import { COLS } from "@/constants/cols";
+
+// APIから取得/APIへ送信するデータの型
+type LayoutData = LayoutItem[];
+
+// --- API通信の関数 ---
+const fetchLayout = async (): Promise<LayoutData> => {
+  const { data } = await axios.get("http://localhost:8000/api/layout");
+  return data;
+};
+
+const saveLayoutApi = async (layout: LayoutData): Promise<void> => {
+  await axios.post("http://localhost:8000/api/layout", layout);
+};
+
+export const useLayout = () => {
+  const queryClient = useQueryClient();
+  const [items, setItems] = useState<LayoutItem[]>([]);
+
+  const { data: initialLayout, isLoading } = useQuery({
+    queryKey: ["layout"],
+    queryFn: fetchLayout,
+  });
+
+  useEffect(() => {
+    if (initialLayout) {
+      setItems(initialLayout);
+    }
+  }, [initialLayout]);
+
+  const mutation = useMutation({
+    mutationFn: saveLayoutApi,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["layout"] });
+      console.log("Layout saved!");
+    },
+  });
+
+  const addedSymbols = useMemo(() => items.map((item) => item.symbol), [items]);
+
+  const findNextAvailablePosition = useCallback(
+    (
+      layout: LayoutItem[],
+      itemWidth: number,
+      itemHeight: number
+    ): { x: number; y: number } => {
+      const cols = COLS.lg; // 最大のcolsを基準に計算
+      let maxY = 0;
+      layout.forEach((item) => {
+        maxY = Math.max(maxY, item.y + item.h);
+      });
+
+      for (let y = 0; y < maxY + itemHeight; y++) {
+        for (let x = 0; x <= cols - itemWidth; x++) {
+          let isSpaceAvailable = true;
+          for (const item of layout) {
+            if (
+              x < item.x + item.w &&
+              x + itemWidth > item.x &&
+              y < item.y + item.h &&
+              y + itemHeight > item.y
+            ) {
+              isSpaceAvailable = false;
+              break;
+            }
+          }
+          if (isSpaceAvailable) {
+            return { x, y };
+          }
+        }
+      }
+      return { x: 0, y: maxY };
+    },
+    []
+  );
+
+  const handleLayoutChange = (newLayout: Layout[]) => {
+    setItems((currentItems) => {
+      const layoutMap = new Map(newLayout.map((l) => [l.i, l]));
+      return currentItems.map((item) => {
+        const layoutUpdate = layoutMap.get(item.i);
+        if (layoutUpdate) {
+          return {
+            ...item,
+            x: layoutUpdate.x,
+            y: layoutUpdate.y,
+            w: layoutUpdate.w,
+            h: layoutUpdate.h,
+          };
+        }
+        return item;
+      });
+    });
+  };
+
+  const saveLayout = () => {
+    mutation.mutate(items);
+  };
+
+  const addMultipleCharts = (
+    symbols: Symbol[],
+    defaultChartSize: { w: number; h: number }
+  ) => {
+    const layoutForPlacement = [...items];
+    const newItems = symbols.map((symbol) => {
+      const { w, h } = defaultChartSize;
+      const { x, y } = findNextAvailablePosition(layoutForPlacement, w, h);
+      const newItem: LayoutItem = {
+        i: `${symbol.value}_${new Date().getTime()}_${Math.random()}`,
+        x,
+        y,
+        w,
+        h,
+        symbol: symbol.value,
+        label: symbol.label,
+      };
+      layoutForPlacement.push(newItem);
+      return newItem;
+    });
+    setItems((prevItems) => [...prevItems, ...newItems]);
+  };
+
+  const removeChart = (itemIdToRemove: string) => {
+    setItems(items.filter((item) => item.i !== itemIdToRemove));
+  };
+
+  return {
+    items,
+    setItems,
+    isLoading,
+    addedSymbols,
+    handleLayoutChange,
+    saveLayout,
+    addMultipleCharts,
+    removeChart,
+  };
+};

--- a/front/types/ChartOptions.ts
+++ b/front/types/ChartOptions.ts
@@ -1,5 +1,4 @@
 // front/types/ChartOptions.ts
-
 // TradingViewウィジェットに直接渡すオプションの型
 export type TradingViewOptions = {
   hide_side_toolbar: boolean;

--- a/front/types/LayoutItem.ts
+++ b/front/types/LayoutItem.ts
@@ -1,0 +1,11 @@
+// front/types/LayoutItem.ts
+// グリッドレイアウトのアイテム
+export type LayoutItem = {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  symbol: string;
+  label: string;
+};

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -1,1 +1,5 @@
 // front/types/index.ts
+export * from "./ChartOptions";
+export * from "./global";
+export * from "./LayoutItem";
+export * from "./Symbol";


### PR DESCRIPTION
### 【概要】
肥大化した`Dashboard`のリファクタリング

### 【修正箇所】
- 肥大化した`Dashboard.tsx`から、以下のカスタムフックを切り出しを行った
  - `useChartSettings.ts`：チャート設定の状態管理カスタムフック
  - `useDashboardModals.ts`：「チャート設定モーダル」「銘柄選択用モーダル」の状態管理カスタムフック
  - `useLayout.ts`：チャートの配置情報の状態管理カスタムフック
- チャート表示以外のヘッダー部分の描画処理を別コンポーネントとして切り出しを行った
  - `DashboardHeader.tsx`：サイト名、各種オプションのヘッダーを表示
  - `HeaderToggleButton.tsx`：ヘッダー部分の非表示機能
- チャート部分のグリッド表示部分を別コンポーネントとして切り出しを行った
  - `ChartGrid.tsx`