### PR TITLE
[feature] ChartWidgetの再レンダリングの調整

### DIFF
--- a/front/components/ChartGrid.tsx
+++ b/front/components/ChartGrid.tsx
@@ -1,5 +1,5 @@
 // front/components/ChartGrid.tsx
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Responsive, WidthProvider } from "react-grid-layout";
 import ChartWidget from "./ChartWidget";
 import { LayoutItem } from "@/types";
@@ -38,10 +38,13 @@ const ChartGrid = ({
     setRemovingItemId(itemId);
   };
 
-  const handleCleanupComplete = (itemId: string) => {
-    onRemoveChart(itemId);
-    setRemovingItemId(null);
-  };
+  const handleCleanupComplete = useCallback(
+    (itemId: string) => {
+      onRemoveChart(itemId);
+      setRemovingItemId(null);
+    },
+    [onRemoveChart]
+  );
 
   return (
     <ResponsiveGridLayout

--- a/front/hooks/useLayout.ts
+++ b/front/hooks/useLayout.ts
@@ -93,7 +93,7 @@ export const useLayout = () => {
     []
   );
 
-  const handleLayoutChange = (newLayout: Layout[]) => {
+  const handleLayoutChange = useCallback((newLayout: Layout[]) => {
     setItems((currentItems) => {
       const layoutMap = new Map(newLayout.map((l) => [l.i, l]));
       return currentItems.map((item) => {
@@ -110,7 +110,7 @@ export const useLayout = () => {
         return item;
       });
     });
-  };
+  }, []);
 
   const saveLayout = () => {
     mutation.mutate(items);
@@ -139,9 +139,11 @@ export const useLayout = () => {
     setItems((prevItems) => [...prevItems, ...newItems]);
   };
 
-  const removeChart = (itemIdToRemove: string) => {
-    setItems(items.filter((item) => item.i !== itemIdToRemove));
-  };
+  const removeChart = useCallback((itemIdToRemove: string) => {
+    setItems((prevItems) =>
+      prevItems.filter((item) => item.i !== itemIdToRemove)
+    );
+  }, []);
 
   return {
     items,


### PR DESCRIPTION
### 【概要】
ChartWidgetの再レンダリングの調整

### 【修正内容】
- チャートの移動やアプリのアクティブ化など、必要の箇所でも再レンダリングを行っていたためその修正を行った
- `useCallback`フックを使用して、コンポーネントの再レンダリング時に不要に関数が再生成されるのを防ぐよう修正を行った