### PR TITLE
[fix] レイアウトの更新が正常に完了しない不具合の修正

### DIFF
--- a/front/app/globals.css
+++ b/front/app/globals.css
@@ -193,3 +193,22 @@ react-resizable-handle-n,
 .react-resizable-handle-se {
   cursor: nwse-resize;
 }
+
+/* --- Toastのスタイル --- */
+.toaster [data-sonner-toast][data-type="success"] {
+  --bg: oklch(0.9 0.1 145 / 0.8); /* 明るい緑 */
+  --fg: oklch(0.2 0.1 145);
+  --border: oklch(0.9 0.1 145);
+  background-color: var(--bg);
+  color: var(--fg);
+  border-color: var(--border);
+}
+
+.toaster [data-sonner-toast][data-type="error"] {
+  --bg: oklch(0.9 0.1 25 / 0.8); /* 明るい赤 */
+  --fg: oklch(0.3 0.1 25);
+  --border: oklch(0.9 0.1 25);
+  background-color: var(--bg);
+  color: var(--fg);
+  border-color: var(--border);
+}

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
 import { ClerkProvider } from "@clerk/nextjs";
+import { Toaster } from "@/components/ui/sonner";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -21,7 +22,10 @@ export default function RootLayout({
     <ClerkProvider>
       <html lang="ja" suppressHydrationWarning>
         <body className={inter.className}>
-          <Providers>{children}</Providers>
+          <Providers>
+            {children}
+            <Toaster />
+          </Providers>
         </body>
       </html>
     </ClerkProvider>

--- a/front/components/ui/sonner.tsx
+++ b/front/components/ui/sonner.tsx
@@ -1,0 +1,33 @@
+// components/ui/sonner.tsx
+"use client";
+
+import { useTheme } from "next-themes";
+import { Toaster as Sonner } from "sonner";
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme();
+
+  return (
+    <Sonner
+      position="top-center"
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/front/hooks/useLayout.ts
+++ b/front/hooks/useLayout.ts
@@ -6,6 +6,7 @@ import axios from "axios";
 import { Layout } from "react-grid-layout";
 import { useAuth } from "@clerk/nextjs";
 
+import { toast } from "sonner";
 import { LayoutItem, Symbol } from "@/types";
 import { COLS } from "@/constants/cols";
 
@@ -51,7 +52,11 @@ export const useLayout = () => {
     mutationFn: saveLayoutApi,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["layout"] });
-      console.log("Layout saved!");
+      toast.success("レイアウトを保存しました");
+    },
+    onError: (error) => {
+      console.error("Layout save failed:", error);
+      toast.error("レイアウトの保存に失敗しました");
     },
   });
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "19.1.0",
         "react-grid-layout": "^1.5.2",
         "shadcn": "^2.10.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -9095,6 +9096,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/front/package.json
+++ b/front/package.json
@@ -29,6 +29,7 @@
     "react-dom": "19.1.0",
     "react-grid-layout": "^1.5.2",
     "shadcn": "^2.10.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### 【概要】
レイアウトの更新が正常に完了しない不具合の修正

### 【不具合の現象】
- DBへチャートの追加・削除は正常に行える
- すでに登録済みのチャートの座標やサイズの情報更新が行われない

### 【原因】
- 既存の処理での更新処理は、一度データの全削除後にフロントから送られてきたデータで全追加する流れだった
- 1回のデータベーストランザクションの中で、同じ主キーを持つデータを「削除」した直後に「追加」しようとしているため
- 主キーの重複エラー（Primary Key Constraint Violation）が発生し、結果としてトランザクション全体が失敗してしまっていた

### 【修正内容】
- 差分更新方式に変更
- `既存レイアウト`と`フロントからのレイアウト`を分けて辞書に登録し処理を行う
- 追加：`既存レイアウト`にIDがなければ追加を行う
- 更新：同じIDのデータがあれば座標データなどを上書きする
- 削除：`フロントからのレイアウト`にIDがなければ削除を行う