### PR TITLE
[feature] チャート配置のレスポンシブ対応

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -21,13 +21,14 @@ class Symbol(SQLModel, table=True):
 # LayoutItemテーブルのモデル
 class LayoutItem(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
-    i: str = Field(unique=True, index=True)
+    i: str
     x: int
     y: int
     w: int
     h: int
     symbol: str
     label: str
+    breakpoint: str
 
     user_id: Optional[int] = Field(default=None, foreign_key="user.id")
     user: Optional[User] = Relationship(back_populates="layouts")

--- a/front/components/ChartGrid.tsx
+++ b/front/components/ChartGrid.tsx
@@ -1,16 +1,23 @@
 // front/components/ChartGrid.tsx
 import { useCallback, useState } from "react";
-import { Responsive, WidthProvider } from "react-grid-layout";
+import {
+  Responsive,
+  WidthProvider,
+  Layouts as ReactGridLayouts,
+} from "react-grid-layout";
 import ChartWidget from "./ChartWidget";
-import { LayoutItem } from "@/types";
+import { LayoutItem, TradingViewOptions, Layouts } from "@/types";
 import { COLS } from "@/constants/cols";
 import { Interval } from "@/constants/intervals";
 import { ChartType } from "@/constants/chartTypes";
-import { TradingViewOptions } from "@/types";
 
 type Props = {
+  layouts: Layouts;
   items: LayoutItem[];
-  onLayoutChange: (layout: ReactGridLayout.Layout[]) => void;
+  onLayoutChange: (
+    layout: ReactGridLayout.Layout[],
+    allLayouts: ReactGridLayouts
+  ) => void;
   onRemoveChart: (itemId: string) => void;
   interval: Interval;
   chartType: ChartType;
@@ -22,6 +29,7 @@ type Props = {
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
 const ChartGrid = ({
+  layouts,
   items,
   onLayoutChange,
   onRemoveChart,
@@ -49,6 +57,7 @@ const ChartGrid = ({
   return (
     <ResponsiveGridLayout
       className={`layout ${isDragging ? "dragging" : ""}`}
+      layouts={layouts}
       cols={COLS}
       rowHeight={16}
       onLayoutChange={onLayoutChange}
@@ -66,13 +75,6 @@ const ChartGrid = ({
       {items.map((item) => (
         <div
           key={item.i}
-          data-grid={{
-            i: item.i,
-            x: item.x,
-            y: item.y,
-            w: item.w,
-            h: item.h,
-          }}
           className="bg-card rounded-lg overflow-hidden border border-border shadow-lg flex flex-col"
         >
           <div className="drag-handle flex items-center pr-2 bg-muted/50 text-muted-foreground">

--- a/front/components/Dashboard.tsx
+++ b/front/components/Dashboard.tsx
@@ -21,17 +21,6 @@ const Dashboard = () => {
   const scriptStatus = useTradingViewScript();
 
   const {
-    items,
-    // setItems,
-    isLoading,
-    addedSymbols,
-    handleLayoutChange,
-    saveLayout,
-    addMultipleCharts,
-    removeChart,
-  } = useLayout();
-
-  const {
     chartSettings,
     setChartSettings,
     interval,
@@ -40,8 +29,20 @@ const Dashboard = () => {
     setChartType,
     widgetOptions,
     enableChartOperation,
-    defaultChartSize,
+    defaultChartSizes,
   } = useChartSettings();
+
+  const {
+    layouts,
+    items,
+    // setItems,
+    isLoading,
+    addedSymbols,
+    handleLayoutChange,
+    saveLayout,
+    addMultipleCharts,
+    removeChart,
+  } = useLayout(defaultChartSizes);
 
   const {
     isSettingsModalOpen,
@@ -58,7 +59,7 @@ const Dashboard = () => {
   };
 
   const handleAddMultipleCharts = (symbols: Symbol[]) => {
-    addMultipleCharts(symbols, defaultChartSize);
+    addMultipleCharts(symbols);
   };
 
   // レイアウト読み込みとスクリプト読み込みの両方が完了するまでローディング表示
@@ -92,6 +93,7 @@ const Dashboard = () => {
         />
         <div className="absolute inset-0">
           <ChartGrid
+            layouts={layouts}
             items={items}
             onLayoutChange={handleLayoutChange}
             onRemoveChart={removeChart}

--- a/front/hooks/useChartSettings.ts
+++ b/front/hooks/useChartSettings.ts
@@ -14,25 +14,24 @@ export const useChartSettings = () => {
     hide_volume: false,
     withdateranges: false,
     enable_chart_operation: false,
-    default_w: 24,
-    default_h: 18,
+    defaultChartSizes: {
+      lg: { w: 24, h: 18 },
+      md: { w: 20, h: 18 },
+      sm: { w: 12, h: 18 },
+      xs: { w: 12, h: 18 },
+      xxs: { w: 12, h: 18 },
+    },
   });
 
   // TradingViewウィジェットに渡すオプションをメモ化
   const widgetOptions: TradingViewOptions = useMemo(() => {
-    const { enable_chart_operation, default_w, default_h, ...rest } =
+    const { enable_chart_operation, defaultChartSizes, ...rest } =
       chartSettings;
     return rest;
   }, [chartSettings]);
 
   const enableChartOperation = chartSettings.enable_chart_operation;
-  const defaultChartSize = useMemo(
-    () => ({
-      w: chartSettings.default_w || 24,
-      h: chartSettings.default_h || 18,
-    }),
-    [chartSettings.default_w, chartSettings.default_h]
-  );
+  const defaultChartSizes = chartSettings.defaultChartSizes;
 
   return {
     interval,
@@ -41,7 +40,7 @@ export const useChartSettings = () => {
     setChartType,
     widgetOptions,
     enableChartOperation,
-    defaultChartSize,
+    defaultChartSizes,
     chartSettings,
     setChartSettings,
   };

--- a/front/types/ChartOptions.ts
+++ b/front/types/ChartOptions.ts
@@ -1,16 +1,26 @@
 // front/types/ChartOptions.ts
 // TradingViewウィジェットに直接渡すオプションの型
-export type TradingViewOptions = {
-  hide_side_toolbar: boolean;
-  hide_top_toolbar: boolean;
-  hide_legend: boolean;
-  hide_volume: boolean;
-  withdateranges: boolean;
+export interface TradingViewOptions {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+  hide_top_toolbar?: boolean;
+  hide_side_toolbar?: boolean;
+  hide_legend?: boolean;
+  hide_volume?: boolean;
+  withdateranges?: boolean;
+}
+
+// デフォルトのチャートサイズの型定義
+export type DefaultChartSizes = {
+  lg: { w: number; h: number };
+  md: { w: number; h: number };
+  sm: { w: number; h: number };
+  xs: { w: number; h: number };
+  xxs: { w: number; h: number };
 };
 
 // 設定モーダルで管理するすべてのオプションをまとめた型
 export type AllChartSettings = TradingViewOptions & {
   enable_chart_operation: boolean;
-  default_w?: number;
-  default_h?: number;
+  defaultChartSizes: DefaultChartSizes;
 };

--- a/front/types/LayoutItem.ts
+++ b/front/types/LayoutItem.ts
@@ -1,11 +1,14 @@
 // front/types/LayoutItem.ts
+import { Layout } from "react-grid-layout";
+
 // グリッドレイアウトのアイテム
-export type LayoutItem = {
+export interface LayoutItem extends Layout {
   i: string;
-  x: number;
-  y: number;
-  w: number;
-  h: number;
   symbol: string;
   label: string;
+}
+
+// 画面サイズごとのレイアウトを格納するオブジェクトの型
+export type Layouts = {
+  [key: string]: LayoutItem[];
 };

--- a/front/types/Symbol.ts
+++ b/front/types/Symbol.ts
@@ -1,6 +1,7 @@
 // front/types/Symbol.ts
 export type Symbol = {
+  id: number;
   label: string;
   value: string;
-  category: string;
+  category: "japan" | "us" | "index" | "fx";
 };


### PR DESCRIPTION
## 【概要】
チャート配置のレスポンシブ対応

## 【目的】
画面サイズの変更（breakpoint)の際にチャート配置が自動調整され、画面サイズを戻しても変更されたチャート座標のままとなっていた
（例：最小の画面サイズにすると基本的にすべてのチャートは縦並びになるため、lgサイズで自分好みに配置をしていたとしても画面サイズを「最小→最大」とするとすべて縦並びになってしまっていた）
各画面サイズでチャートのサイズ・座標を保存するように修正を行った

## 【修正内容】
### バックエンド
- 各画面サイズ毎にも保存するように修正
- 各画面サイズ毎に`i`(銘柄名)が存在するため、既存の銘柄名＝ユニークの属性は不要となった

### フロントエンド
- 各画面サイズの情報を保持するため、`type Layouts = {[key: string]: LayoutItem[]}`を定義し、チャート情報の配列を保持できるように修正
- `useLayout.ts`で上記の`Layouts`のキーに各サイズを定義し、チャートの追加時や変更時に各サイズのチャート情報を修正することで対応