### PR TITLE
[feature] デフォルトチャートサイズの変更を現在のサイズのみに限定した

### DIFF
--- a/front/app/globals.css
+++ b/front/app/globals.css
@@ -146,10 +146,39 @@
 /* ドラッグ中にグリッド線を表示 */
 .react-grid-layout.dragging {
   /* グリッドのサイズをrowHeightとcolsから計算した値に合わせる */
-  /* この値はDashboard.tsxのcolsとrowHeightに依存します */
-  background-size: calc(100% / 72) 16px;
+  /* xxsの列数 */
+  --grid-cols: 12;
+  background-size: calc(100% / var(--grid-cols)) 16px;
   background-image: linear-gradient(to right, #4b5563 1px, transparent 1px),
     linear-gradient(to bottom, #4b5563 1px, transparent 1px);
+}
+
+/* xs: 480px以上 */
+@media (min-width: 480px) {
+  .react-grid-layout.dragging {
+    --grid-cols: 24;
+  }
+}
+
+/* sm: 768px以上 */
+@media (min-width: 768px) {
+  .react-grid-layout.dragging {
+    --grid-cols: 36;
+  }
+}
+
+/* md: 1024px以上 */
+@media (min-width: 1024px) {
+  .react-grid-layout.dragging {
+    --grid-cols: 60;
+  }
+}
+
+/* lg: 1280px以上 */
+@media (min-width: 1280px) {
+  .react-grid-layout.dragging {
+    --grid-cols: 72;
+  }
 }
 
 /* ドラッグ時のプレースホルダーの設定 */

--- a/front/hooks/useBreakpoint.ts
+++ b/front/hooks/useBreakpoint.ts
@@ -1,0 +1,39 @@
+// front/hooks/useBreakpoint.ts
+
+import { useEffect, useState } from "react";
+import { COLS } from "@/constants/cols";
+
+type Breakpoint = keyof typeof COLS;
+
+const BREAKPOINT_WIDTHS: Record<string, number> = {
+  lg: 1280,
+  md: 1024,
+  sm: 768,
+  xs: 480,
+  xxs: 0,
+};
+
+const getBreakpoint = (width: number): Breakpoint => {
+  const sortedBreakpoints = (
+    Object.keys(BREAKPOINT_WIDTHS) as Breakpoint[]
+  ).sort((a, b) => BREAKPOINT_WIDTHS[b] - BREAKPOINT_WIDTHS[a]);
+  return (
+    sortedBreakpoints.find((bp) => width >= BREAKPOINT_WIDTHS[bp]) ?? "xxs"
+  );
+};
+
+export const useBreakpoint = (): Breakpoint => {
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>("lg");
+
+  useEffect(() => {
+    const handleResize = () => {
+      setBreakpoint(getBreakpoint(window.innerWidth));
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return breakpoint;
+};

--- a/front/hooks/useChartSettings.ts
+++ b/front/hooks/useChartSettings.ts
@@ -1,18 +1,29 @@
 // front/hooks/useChartSettings.ts
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { Interval } from "@/constants/intervals";
 import { ChartType } from "@/constants/chartTypes";
 import { AllChartSettings, TradingViewOptions } from "@/types";
 
+// オブジェクトが等しいか簡易的にチェックする関数
+const simpleDeepEqual = (objA: unknown, objB: unknown) => {
+  return JSON.stringify(objA) === JSON.stringify(objB);
+};
+
 export const useChartSettings = () => {
   const [interval, setInterval] = useState<Interval>("30");
   const [chartType, setChartType] = useState<ChartType>("candles");
-  const [chartSettings, setChartSettings] = useState<AllChartSettings>({
+
+  // TradingViewウィジェットに直接関わる設定
+  const [widgetOptions, setWidgetOptions] = useState<TradingViewOptions>({
     hide_top_toolbar: true,
     hide_side_toolbar: true,
     hide_legend: false,
     hide_volume: false,
     withdateranges: false,
+  });
+
+  // それ以外のチャートに関する設定
+  const [behaviorSettings, setBehaviorSettings] = useState({
     enable_chart_operation: false,
     defaultChartSizes: {
       lg: { w: 24, h: 18 },
@@ -23,15 +34,36 @@ export const useChartSettings = () => {
     },
   });
 
-  // TradingViewウィジェットに渡すオプションをメモ化
-  const widgetOptions: TradingViewOptions = useMemo(() => {
-    const { enable_chart_operation, defaultChartSizes, ...rest } =
-      chartSettings;
-    return rest;
-  }, [chartSettings]);
+  const chartSettings: AllChartSettings = useMemo(
+    () => ({
+      ...widgetOptions,
+      ...behaviorSettings,
+    }),
+    [widgetOptions, behaviorSettings]
+  );
 
-  const enableChartOperation = chartSettings.enable_chart_operation;
-  const defaultChartSizes = chartSettings.defaultChartSizes;
+  const setChartSettings = useCallback(
+    (newSettings: AllChartSettings) => {
+      // 新しい設定を「ウィジェット用」と「動作設定用」に分割
+      const { enable_chart_operation, defaultChartSizes, ...newWidgetOptions } =
+        newSettings;
+
+      const newBehaviorSettings = {
+        enable_chart_operation,
+        defaultChartSizes,
+      };
+
+      // 差分をチェックして、変更があったものだけを更新する
+      if (!simpleDeepEqual(widgetOptions, newWidgetOptions)) {
+        setWidgetOptions(newWidgetOptions);
+      }
+
+      if (!simpleDeepEqual(behaviorSettings, newBehaviorSettings)) {
+        setBehaviorSettings(newBehaviorSettings);
+      }
+    },
+    [widgetOptions, behaviorSettings]
+  );
 
   return {
     interval,
@@ -39,8 +71,8 @@ export const useChartSettings = () => {
     chartType,
     setChartType,
     widgetOptions,
-    enableChartOperation,
-    defaultChartSizes,
+    enableChartOperation: behaviorSettings.enable_chart_operation,
+    defaultChartSizes: behaviorSettings.defaultChartSizes,
     chartSettings,
     setChartSettings,
   };


### PR DESCRIPTION
## 【概要】
- デフォルトチャートサイズの変更を現在のサイズのみに限定
- 不要な再レンダリングの抑制
- 一部のバグの修正

## 【目的】
### 現在のサイズのみに限定
従来はチャート設定モーダルでチャートのデフォルトサイズを変更する際に、すべての画面サイズの設定項目が表示されていたため煩雑となっていた
これを現在の画面サイズのみ変更するように修正を行った

### 不要な再レンダリングの抑制
直接チャートを描画に関わる設定以外の設定変更でも再レンダリングが発生していた
これを修正

### バグ
各画面サイズのカラム数と実際の画面上でのカラム数（グリッド線の数）が揃っていなかった
CSSで常に幅72カラムに固定されていたのが原因
これを修正

## 【修正内容】
### 現在のサイズのみに限定
- 現在の画面サイズ(`breakpoint`)を取得するためのカスタムフック(`useBreakpoint.ts`)を作成
- 取得した画面サイズ情報を表示
- 設定変更が行われた場合は取得していた画面サイズのデフォルトチャートサイズを変更


### 不要な再レンダリングの抑制
- `TradingViewWidget`関係以外の設定も同一オブジェクトで定義し、まとめて更新を行っていたためこれを分離

### バグ
- CSSで各画面サイズに応じたカラム数を設定