### PR TITLE
[fix] フロントエンドのビルドエラーの修正

### DIFF
--- a/front/app/@modal/(.)upgrade/page.tsx
+++ b/front/app/@modal/(.)upgrade/page.tsx
@@ -5,7 +5,12 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
 
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useUserStatus } from "@/hooks/useUserStatus";
 import { CheckoutWrapper } from "@/components/CheckoutWrapper";
 import { UpgradeView } from "@/components/UpgradeView";
@@ -39,7 +44,11 @@ const InterceptedUpgradePage = () => {
         {!isLoading && !isPremium && (
           <>
             {view === "benefits" && (
-              <UpgradeView onProceed={() => setView("payment")} />
+              <DialogHeader>
+                <DialogTitle>
+                  <UpgradeView onProceed={() => setView("payment")} />
+                </DialogTitle>
+              </DialogHeader>
             )}
             {view === "payment" && <CheckoutWrapper />}
           </>

--- a/front/app/@modal/(.)upgrade/success/page.tsx
+++ b/front/app/@modal/(.)upgrade/success/page.tsx
@@ -13,21 +13,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
-const SuccessView = ({ onClose }: { onClose: () => void }) => (
-  <div className="rounded-lg border bg-card p-8 text-center shadow-lg">
-    <CheckCircle className="mx-auto h-16 w-16 text-green-500" />
-    <DialogHeader className="space-y-2 mt-6 text-center">
-      <DialogTitle asChild>
-        <h1 className="text-3xl font-bold">アップグレード完了</h1>
-      </DialogTitle>
-      <p className="text-lg text-muted-foreground">ありがとうございます。</p>
-    </DialogHeader>
-    <Button onClick={onClose} size="lg" className="mt-6 w-full">
-      ダッシュボードへ戻る
-    </Button>
-  </div>
-);
-
 const InterceptedSuccessPage = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
@@ -37,6 +22,10 @@ const InterceptedSuccessPage = () => {
     // ユーザー情報を再取得してヘッダーの表示などを更新
     queryClient.invalidateQueries({ queryKey: ["userStatus"] });
   }, [queryClient]);
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
 
   useEffect(() => {
     if (!isOpen) {
@@ -50,7 +39,20 @@ const InterceptedSuccessPage = () => {
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogContent className="p-0 border-0 bg-transparent shadow-none w-full max-w-md">
-        <SuccessView onClose={() => setIsOpen(false)} />
+        <div className="rounded-lg border bg-card p-8 text-center shadow-lg">
+          <CheckCircle className="mx-auto h-16 w-16 text-green-500" />
+          <DialogHeader className="space-y-2 mt-6 text-center">
+            <DialogTitle asChild>
+              <h1 className="text-3xl font-bold">アップグレード完了</h1>
+            </DialogTitle>
+            <p className="text-lg text-muted-foreground">
+              ありがとうございます。
+            </p>
+          </DialogHeader>
+          <Button onClick={handleClose} size="lg" className="mt-6 w-full">
+            ダッシュボードへ戻る
+          </Button>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/front/components/UpgradeView.tsx
+++ b/front/components/UpgradeView.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
   NORMAL_USER_MAX_CHARTS,
   PREMIUM_USER_MAX_CHARTS,
@@ -23,11 +22,7 @@ type Props = {
 export const UpgradeView = ({ onProceed }: Props) => {
   return (
     <div className="rounded-lg border bg-card p-6 text-foreground shadow-lg">
-      <DialogHeader>
-        <DialogTitle asChild>
-          <h2 className="text-2xl font-bold text-center">KABUKAWA View Pro</h2>
-        </DialogTitle>
-      </DialogHeader>
+      <h2 className="text-2xl font-bold text-center">KABUKAWA View Pro</h2>
 
       <div className="my-6">
         <p className="text-center text-muted-foreground">


### PR DESCRIPTION
### 【概要】
フロントエンドのビルドエラーの修正

### 【修正内容】
- `DialogTitle`は`Dialog`にラップされている必要があるが、`DialogTitle`部分だけ関数・コンポーネントに切り出していたため、ブラウザ上では問題が出なかったが、Next.jsがビルド時に静的解析を行う際に関数・コンポーネントを単体で評価しようとしてしまいエラーが発生した
- 関数の切り出しをやめることで対応
- 切り出したコンポーネント側では使用せず、呼び出し元でラップすることで対応