### PR TITLE
[fix] バックエンドAPIのURLを指定

### DIFF
--- a/front/constants/config.ts
+++ b/front/constants/config.ts
@@ -1,5 +1,5 @@
 // front/constants/config.ts
-export const API_URL = "http://localhost:8000";
+export const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
 // チャート数の上限
 export const NORMAL_USER_MAX_CHARTS = 5;


### PR DESCRIPTION
### 【概要】
バックエンドAPIのURLを指定

### 【修正内容】
- ローカルのAPI_URLをハードコーディングしたままだったため、これを修正