### PR TITLE
[feature] tanQueryのキャッシュ更新タイミングの調整

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -319,9 +319,3 @@ async def stripe_webhook(
                 session.commit()
 
     return {"status": "success"}
-
-# 仮想環境の起動方法：
-# .\venv\Scripts\Activate
-# deactivate
-# サーバーの起動方法:
-# ターミナルで `uvicorn main:app --reload` を実行

--- a/front/app/providers.tsx
+++ b/front/app/providers.tsx
@@ -6,7 +6,19 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // ウィンドウがフォーカスされた時に自動で再取得する機能を無効化
+            refetchOnWindowFocus: false,
+            // ネットワークが再接続された時に自動で再取得する機能を無効化
+            refetchOnReconnect: false,
+          },
+        },
+      })
+  );
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>


### PR DESCRIPTION
### 【概要】
tanQueryのキャッシュ更新タイミングの調整

### 【修正内容】
- 高頻度でチャートの再描画処理が走っていたため、tanQueryの更新タイミングを変更した
  - タブの切り替えやブラウザの非アクティブ化では再取得を行わない
  - ネットワークの再接続時にも再取得を行わない