### PR TITLE
[feature] 冪等性担保のための処理を追加

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -8,6 +8,7 @@ class User(SQLModel, table=True):
     user_id: str = Field(unique=True, index=True)
     email: str
     is_premium: bool = Field(default=False)
+    stripe_payment_intent_id: Optional[str] = Field(default=None, index=True)
 
     layouts: List["LayoutItem"] = Relationship(back_populates="user")
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -20,6 +20,7 @@
         "@stripe/react-stripe-js": "^4.0.2",
         "@stripe/stripe-js": "^7.9.0",
         "@tanstack/react-query": "^5.85.5",
+        "@types/uuid": "^10.0.0",
         "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -31,7 +32,8 @@
         "react-grid-layout": "^1.5.2",
         "shadcn": "^2.10.0",
         "sonner": "^2.0.7",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2938,6 +2940,12 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -10041,6 +10049,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -21,6 +21,7 @@
     "@stripe/react-stripe-js": "^4.0.2",
     "@stripe/stripe-js": "^7.9.0",
     "@tanstack/react-query": "^5.85.5",
+    "@types/uuid": "^10.0.0",
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -32,7 +33,8 @@
     "react-grid-layout": "^1.5.2",
     "shadcn": "^2.10.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## 【概要】
冪等性（何度実行しても、その結果が1度だけ実行したときと同じになる性質）担保のための処理を追加

## 【目的】
以下の3つの観点から冪等性を確保
- 【APIリクエスト層】Idempotency-Keyによる重複リクエストの防止
  - 役割: ネットワークエラーによるAPIリクエストの再試行や、ユーザーによるボタン連打からサーバーを保護する。
  - 仕組み: フロントエンドで決済ごとにユニークなIDを生成し、それをIdempotency-KeyとしてAPIリクエストに含める。Stripeサーバーはこのキーを見て、同じキーを持つリクエストを一度しか処理しないことを保証する。
- 【ビジネスロジック層】バックエンドでの支払い状態管理
  - 役割: ユーザーがページをリロード・再アクセスを行っても、常に一貫した支払いフローを提供する。
  - 仕組み: ユーザーごとに未完了のPaymentIntentをデータベースに保存し、それを再利用することで無駄な支払い情報が作られるのを防ぐ。
- 【データベース層】悲観的ロックによる同時実行制御
  - 役割: 複数のリクエストが全く同じタイミングでサーバーに到達した場合の競合状態（レースコンディション）を防ぐ。
  - 仕組み: データベースのユーザー情報を更新する際に、そのデータ行をロックする。これにより、最初の処理が終わるまで、他の処理は待機状態となりデータの不整合を防ぐ。

## 【修正内容】
### バックエンド
- DBの`User`テーブルに冪等性キー(`stripe_payment_intent_id`)を追加
- ユーザー情報更新時に行をロックする処理(`get_current_user_for_update`)を追加
- 冪等性確保のための処理を追加

### フロントエンド
- 冪等性キー生成処理を追加(`Version 4 UUID`により生成)
- 決算リクエストのヘッダーに冪等性キーを追加
- 決算リクエストの実行は1度で良いため、`useEffect`の依存配列を見直した(空とした)