### PR TITLE
[feature] サブスクリプション型の課金プラン機能を追加

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,6 +1,7 @@
 # api/models.py
 from typing import List, Optional
 from sqlmodel import Field, Relationship, SQLModel
+from datetime import datetime
 
 # Usersテーブルのモデル
 class User(SQLModel, table=True):
@@ -9,6 +10,9 @@ class User(SQLModel, table=True):
     email: str
     is_premium: bool = Field(default=False)
     stripe_payment_intent_id: Optional[str] = Field(default=None, index=True)
+    stripe_customer_id: Optional[str] = Field(default=None, unique=True, index=True)
+    stripe_subscription_id: Optional[str] = Field(default=None, unique=True)
+    subscription_end_date: Optional[datetime] = Field(default=None)
 
     layouts: List["LayoutItem"] = Relationship(back_populates="user")
 

--- a/front/app/@modal/(.)upgrade/page.tsx
+++ b/front/app/@modal/(.)upgrade/page.tsx
@@ -14,15 +14,22 @@ import {
 import { useUserStatus } from "@/hooks/useUserStatus";
 import { CheckoutWrapper } from "@/components/CheckoutWrapper";
 import { UpgradeView } from "@/components/UpgradeView";
+import { Plan } from "@/types";
 
 const InterceptedUpgradePage = () => {
-  const { isPremium, isLoading } = useUserStatus();
+  const { status, isLoading } = useUserStatus();
   const [view, setView] = useState<"benefits" | "payment">("benefits");
+  const [selectedPlan, setSelectedPlan] = useState<Plan>("one_time");
   const router = useRouter();
 
   const handleClose = () => {
     // トップページに遷移することで、モーダルを閉じる
     router.back();
+  };
+
+  const handleProceed = (plan: Plan) => {
+    setSelectedPlan(plan);
+    setView("payment");
   };
 
   return (
@@ -41,16 +48,16 @@ const InterceptedUpgradePage = () => {
             <Loader2 className="mx-auto h-8 w-8 animate-spin text-white" />
           </div>
         )}
-        {!isLoading && !isPremium && (
+        {!isLoading && status !== "lifetime" && (
           <>
             {view === "benefits" && (
               <DialogHeader>
                 <DialogTitle>
-                  <UpgradeView onProceed={() => setView("payment")} />
+                  <UpgradeView onProceed={handleProceed} />
                 </DialogTitle>
               </DialogHeader>
             )}
-            {view === "payment" && <CheckoutWrapper />}
+            {view === "payment" && <CheckoutWrapper plan={selectedPlan} />}
           </>
         )}
       </DialogContent>

--- a/front/app/upgrade/page.tsx
+++ b/front/app/upgrade/page.tsx
@@ -9,10 +9,17 @@ import { Button } from "@/components/ui/button";
 import { useUserStatus } from "@/hooks/useUserStatus";
 import { CheckoutWrapper } from "@/components/CheckoutWrapper";
 import { UpgradeView } from "@/components/UpgradeView";
+import { Plan } from "@/types";
 
 const UpgradePage = () => {
-  const { isPremium, isLoading, error } = useUserStatus();
+  const { status, isLoading, error } = useUserStatus();
   const [view, setView] = useState<"benefits" | "payment">("benefits");
+  const [selectedPlan, setSelectedPlan] = useState<Plan>("one_time");
+
+  const handleProceed = (plan: Plan) => {
+    setSelectedPlan(plan);
+    setView("payment");
+  };
 
   return (
     <div className="container mx-auto flex min-h-screen flex-col items-center justify-center p-4">
@@ -31,10 +38,10 @@ const UpgradePage = () => {
           </div>
         )}
 
-        {!isLoading && isPremium && (
+        {!isLoading && status === "lifetime" && (
           <div className="rounded-lg border bg-card p-8 text-center shadow-lg">
             <h2 className="text-xl font-semibold">
-              既にプレミアムプランにご登録済みです
+              既に買い切りプランにご登録済みです
             </h2>
             <Button asChild className="mt-6">
               <Link href="/">トップページへ戻る</Link>
@@ -42,16 +49,16 @@ const UpgradePage = () => {
           </div>
         )}
 
-        {!isLoading && !isPremium && (
+        {!isLoading && status !== "lifetime" && (
           <>
             {view === "benefits" ? (
               <div className="max-w-md mx-auto">
-                <UpgradeView onProceed={() => setView("payment")} />
+                <UpgradeView onProceed={handleProceed} />
               </div>
             ) : (
               <div className="flex flex-col lg:flex-row gap-8">
                 <div className="lg:w-2/3">
-                  <CheckoutWrapper />
+                  <CheckoutWrapper plan={selectedPlan} />
                 </div>
               </div>
             )}

--- a/front/components/PaymentForm.tsx
+++ b/front/components/PaymentForm.tsx
@@ -46,24 +46,18 @@ export const PaymentForm = ({ clientSecret }: PaymentFormProps) => {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (!stripe || !elements || !elements.getElement(CardNumberElement)) {
+      return;
+    }
+
     setIsLoading(true);
-
-    if (!stripe || !elements) {
-      setIsLoading(false);
-      return;
-    }
-
-    const cardNumberElement = elements.getElement(CardNumberElement);
-    if (!cardNumberElement) {
-      setIsLoading(false);
-      return;
-    }
 
     const { error, paymentIntent } = await stripe.confirmCardPayment(
       clientSecret,
       {
         payment_method: {
-          card: cardNumberElement,
+          card: elements.getElement(CardNumberElement)!,
           billing_details: {
             name: cardHolderName,
           },
@@ -127,7 +121,7 @@ export const PaymentForm = ({ clientSecret }: PaymentFormProps) => {
           className="w-full mt-6"
         >
           {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-          支払う (¥500)
+          支払う
         </Button>
       </form>
     </div>

--- a/front/components/UpgradeButton.tsx
+++ b/front/components/UpgradeButton.tsx
@@ -7,8 +7,16 @@ import { Crown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useUserStatus } from "@/hooks/useUserStatus";
 
+const calculateRemainingDays = (endDate: Date | null): number => {
+  if (!endDate) return 0;
+  const now = new Date();
+  const diffTime = endDate.getTime() - now.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  return diffDays > 0 ? diffDays : 0;
+};
+
 export const UpgradeButton = () => {
-  const { isPremium, isLoading } = useUserStatus();
+  const { status, subscriptionEndDate, isLoading } = useUserStatus();
 
   if (isLoading) {
     return (
@@ -18,11 +26,27 @@ export const UpgradeButton = () => {
     );
   }
 
-  // プレミアムユーザーの場合の表示
-  if (isPremium) {
+  // 買い切りユーザーの場合
+  if (status === "lifetime") {
     return (
       <Button variant="outline" disabled className="w-[130px]">
         <Crown className="mr-2 h-4 w-4 text-yellow-500" /> Pro
+      </Button>
+    );
+  }
+
+  // サブスクユーザーの場合
+  if (status === "subscribed") {
+    const remainingDays = calculateRemainingDays(subscriptionEndDate);
+    return (
+      <Button asChild className="w-[130px] h-auto flex-col items-center py-1.5">
+        <Link href="/upgrade">
+          <div className="flex items-center">
+            <Crown className="mr-2 h-4 w-4 text-yellow-500" /> Pro{" "}
+            <span className="text-xs ml-1">(Sub)</span>
+          </div>
+          <div className="text-xs mt-0.5">残り {remainingDays} 日</div>
+        </Link>
       </Button>
     );
   }

--- a/front/components/UpgradeView.tsx
+++ b/front/components/UpgradeView.tsx
@@ -1,12 +1,17 @@
 // front/components/UpgradeView.tsx
 "use client";
 
+import { useState } from "react";
+import { Check, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
 import { Button } from "@/components/ui/button";
+import { Plan } from "@/types";
 import {
   NORMAL_USER_MAX_CHARTS,
   PREMIUM_USER_MAX_CHARTS,
 } from "@/constants/config";
-import { Check } from "lucide-react";
+import { usePrices } from "@/hooks/usePrices";
 
 const ListItem = ({ children }: { children: React.ReactNode }) => (
   <li className="flex items-start gap-3">
@@ -16,23 +21,79 @@ const ListItem = ({ children }: { children: React.ReactNode }) => (
 );
 
 type Props = {
-  onProceed: () => void;
+  onProceed: (plan: Plan) => void;
+};
+
+const formatCurrency = (amount: number | undefined) => {
+  if (typeof amount !== "number") return "---";
+  return new Intl.NumberFormat("ja-JP", {
+    style: "currency",
+    currency: "JPY",
+    minimumFractionDigits: 0,
+  }).format(amount);
 };
 
 export const UpgradeView = ({ onProceed }: Props) => {
+  const [selectedPlan, setSelectedPlan] = useState<Plan>("one_time");
+  const { prices, isLoading, error } = usePrices();
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border bg-card p-6 text-foreground shadow-lg flex justify-center items-center h-[450px]">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (error || !prices) {
+    return (
+      <div className="rounded-lg border bg-card p-6 text-destructive-foreground shadow-lg text-center">
+        <h2 className="text-xl font-bold">エラー</h2>
+        <p className="mt-4">価格情報の取得に失敗しました。</p>
+        <p className="text-sm mt-1">時間をおいて再度お試しください。</p>
+      </div>
+    );
+  }
+
   return (
     <div className="rounded-lg border bg-card p-6 text-foreground shadow-lg">
       <h2 className="text-2xl font-bold text-center">KABUKAWA View Pro</h2>
 
       <div className="my-6">
         <p className="text-center text-muted-foreground">
-          プレミアムプランにアップグレードして、全ての機能を開放しましょう。
+          アップグレードして、全ての機能を開放しましょう。
         </p>
-        <div className="my-6 text-center">
-          <span className="text-5xl font-extrabold">¥500</span>
-          <span className="ml-2 text-xl font-medium text-muted-foreground">
-            / 買い切り
-          </span>
+
+        {/* --- プラン選択 --- */}
+        <div className="mt-6 grid grid-cols-2 gap-4">
+          <div
+            className={cn(
+              "rounded-lg border p-4 text-center cursor-pointer transition-all",
+              selectedPlan === "one_time" &&
+                "ring-2 ring-primary border-primary"
+            )}
+            onClick={() => setSelectedPlan("one_time")}
+          >
+            <h3 className="font-semibold">買い切り</h3>
+            <p className="text-2xl font-bold mt-2">
+              {formatCurrency(prices.one_time?.amount)}
+            </p>
+            <p className="text-xs text-muted-foreground">一括払い</p>
+          </div>
+          <div
+            className={cn(
+              "rounded-lg border p-4 text-center cursor-pointer transition-all",
+              selectedPlan === "subscription" &&
+                "ring-2 ring-primary border-primary"
+            )}
+            onClick={() => setSelectedPlan("subscription")}
+          >
+            <h3 className="font-semibold">サブスク</h3>
+            <p className="text-2xl font-bold mt-2">
+              {formatCurrency(prices.subscription?.amount)}
+            </p>
+            <p className="text-xs text-muted-foreground">/ 月</p>
+          </div>
         </div>
       </div>
 
@@ -51,7 +112,11 @@ export const UpgradeView = ({ onProceed }: Props) => {
           お問い合わせに優先的に対応します。(将来実装予定)
         </ListItem> */}
       </ul>
-      <Button onClick={onProceed} className="mt-8 w-full" size="lg">
+      <Button
+        onClick={() => onProceed(selectedPlan)}
+        className="mt-8 w-full"
+        size="lg"
+      >
         アップグレードに進む
       </Button>
     </div>

--- a/front/hooks/usePrices.ts
+++ b/front/hooks/usePrices.ts
@@ -1,0 +1,37 @@
+// front/hooks/usePrices.ts
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+import { API_URL } from "@/constants/config";
+
+type PriceInfo = {
+  id: string;
+  amount: number;
+};
+
+type PricesResponse = {
+  one_time: PriceInfo | null;
+  subscription: PriceInfo | null;
+};
+
+const fetchPrices = async (): Promise<PricesResponse> => {
+  const { data } = await axios.get(`${API_URL}/api/prices`);
+  return data;
+};
+
+export const usePrices = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["prices"],
+    queryFn: fetchPrices,
+    staleTime: 1000 * 60 * 60,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    prices: data,
+    isLoading,
+    error,
+  };
+};

--- a/front/types/Plan.ts
+++ b/front/types/Plan.ts
@@ -1,0 +1,2 @@
+// front/types/Plan.ts
+export type Plan = "one_time" | "subscription";

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -3,3 +3,4 @@ export * from "./ChartOptions";
 export * from "./global";
 export * from "./LayoutItem";
 export * from "./Symbol";
+export * from "./Plan";


### PR DESCRIPTION
## 【概要】
サブスクリプション型の課金プラン機能を追加
各プランの価格も柔軟に対応可能とした

## 【目的】
- 従来の買い切り型のプランだけではなく、サブスクリプション型のプランも用意し好きなプランで選べるようにした
- 各プランの価格をStripeのダッシュボードから変更可能とした

##【修正内容】
### バックエンド
- 現在の加入プランを返すエンドポイントを作成（従来のものを修正）
- 買い切りプランのエンドポイントをStripeで設定された価格に設定するよう修正
- サブスクプラン用のエンドポイントを作成
- 各プランの価格取得用エンドポイントの作成
- DBへサブスクプラン用のカラムを追加

### フロントエンド
- 現在のプラン状況（`none`,`lifetime`,`subscribed`)に応じた処理を行うよう修正
- サブスクプラン用の`payment-intent`作成処理を追加(`CheckoutWrapper.tsx`)
- 価格情報はバックエンドを通じてStripeから取得するよう修正

## 【スクリーンショット】
<img width="563" height="514" alt="image" src="https://github.com/user-attachments/assets/c2c5eacc-2aaa-47bd-8412-88cd7245d73d" />
