### PR TITLE
[feature] サブスクプランのキャンセル予約処理の実装

### DIFF
--- a/front/app/upgrade/page.tsx
+++ b/front/app/upgrade/page.tsx
@@ -10,6 +10,7 @@ import { useUserStatus } from "@/hooks/useUserStatus";
 import { CheckoutWrapper } from "@/components/CheckoutWrapper";
 import { UpgradeView } from "@/components/UpgradeView";
 import { Plan } from "@/types";
+import { SubscribedView } from "@/components/SubscribedView";
 
 const UpgradePage = () => {
   const { status, isLoading, error } = useUserStatus();
@@ -21,50 +22,72 @@ const UpgradePage = () => {
     setView("payment");
   };
 
+  const handleUpgradeToOneTime = () => {
+    setSelectedPlan("one_time");
+    setView("payment");
+  };
+
+  const renderContent = () => {
+    if (isLoading) {
+      return <Loader2 className="mx-auto h-8 w-8 animate-spin" />;
+    }
+
+    if (error) {
+      return (
+        <div className="rounded-lg border bg-card p-8 text-center shadow-lg">
+          <h2 className="text-xl font-semibold">エラーが発生しました</h2>
+          <p className="mt-2 text-muted-foreground">
+            ユーザー情報の取得に失敗しました。
+          </p>
+          <Button asChild className="mt-6">
+            <Link href="/">トップページへ戻る</Link>
+          </Button>
+        </div>
+      );
+    }
+
+    if (status === "lifetime") {
+      return (
+        <div className="rounded-lg border bg-card p-8 text-center shadow-lg">
+          <h2 className="text-xl font-semibold">
+            既に買い切りプランにご登録済みです
+          </h2>
+          <Button asChild className="mt-6">
+            <Link href="/">トップページへ戻る</Link>
+          </Button>
+        </div>
+      );
+    }
+
+    if (view === "payment") {
+      return (
+        <div className="flex flex-col lg:flex-row gap-8 justify-center">
+          <div className="w-full max-w-md">
+            <CheckoutWrapper plan={selectedPlan} />
+          </div>
+        </div>
+      );
+    }
+
+    if (status === "subscribed") {
+      return (
+        <div className="max-w-md mx-auto">
+          <SubscribedView onUpgradeToOneTime={handleUpgradeToOneTime} />
+        </div>
+      );
+    }
+
+    // status === 'none'
+    return (
+      <div className="max-w-md mx-auto">
+        <UpgradeView onProceed={handleProceed} />
+      </div>
+    );
+  };
+
   return (
     <div className="container mx-auto flex min-h-screen flex-col items-center justify-center p-4">
-      <div className="w-full max-w-4xl">
-        {isLoading && <Loader2 className="mx-auto h-8 w-8 animate-spin" />}
-
-        {error && (
-          <div className="rounded-lg border bg-card p-8 text-center shadow-lg">
-            <h2 className="text-xl font-semibold">エラーが発生しました</h2>
-            <p className="mt-2 text-muted-foreground">
-              ユーザー情報の取得に失敗しました。
-            </p>
-            <Button asChild className="mt-6">
-              <Link href="/">トップページへ戻る</Link>
-            </Button>
-          </div>
-        )}
-
-        {!isLoading && status === "lifetime" && (
-          <div className="rounded-lg border bg-card p-8 text-center shadow-lg">
-            <h2 className="text-xl font-semibold">
-              既に買い切りプランにご登録済みです
-            </h2>
-            <Button asChild className="mt-6">
-              <Link href="/">トップページへ戻る</Link>
-            </Button>
-          </div>
-        )}
-
-        {!isLoading && status !== "lifetime" && (
-          <>
-            {view === "benefits" ? (
-              <div className="max-w-md mx-auto">
-                <UpgradeView onProceed={handleProceed} />
-              </div>
-            ) : (
-              <div className="flex flex-col lg:flex-row gap-8">
-                <div className="lg:w-2/3">
-                  <CheckoutWrapper plan={selectedPlan} />
-                </div>
-              </div>
-            )}
-          </>
-        )}
-      </div>
+      <div className="w-full max-w-4xl">{renderContent()}</div>
     </div>
   );
 };

--- a/front/components/SubscribedView.tsx
+++ b/front/components/SubscribedView.tsx
@@ -1,0 +1,119 @@
+// front/components/SubscribedView.tsx
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { useAuth } from "@clerk/nextjs";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { API_URL } from "@/constants/config";
+import { useUserStatus } from "@/hooks/useUserStatus";
+
+type Props = {
+  onUpgradeToOneTime: () => void;
+};
+
+const cancelSubscription = async (token: string | null) => {
+  if (!token) {
+    throw new Error("Authentication token not found.");
+  }
+  await axios.post(
+    `${API_URL}/api/cancel-subscription`,
+    {},
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  );
+};
+
+export const SubscribedView = ({ onUpgradeToOneTime }: Props) => {
+  const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+  const { cancelAtPeriodEnd, subscriptionEndDate } = useUserStatus();
+
+  const mutation = useMutation({
+    mutationFn: () => getToken().then(cancelSubscription),
+    onSuccess: () => {
+      toast.success("サブスクリプションの解約を予約しました。");
+      queryClient.invalidateQueries({ queryKey: ["userStatus"] });
+      setIsCancelDialogOpen(false);
+    },
+    onError: (error) => {
+      const errorMessage =
+        axios.isAxiosError(error) && error.response
+          ? error.response.data.detail
+          : "サブスクリプションの解約に失敗しました。";
+      toast.error(errorMessage);
+    },
+  });
+
+  return (
+    <div className="rounded-lg border bg-card p-6 text-foreground shadow-lg text-center">
+      <h2 className="text-2xl font-bold">プラン管理</h2>
+      <p className="text-muted-foreground mt-2 mb-6">
+        {cancelAtPeriodEnd && subscriptionEndDate
+          ? `${subscriptionEndDate.toLocaleDateString()}に解約予定です。`
+          : "現在サブスクリプションプランをご利用中です。"}
+      </p>
+
+      <div className="flex flex-col gap-4">
+        <Button onClick={onUpgradeToOneTime} size="lg">
+          買い切りプランにアップグレード
+        </Button>
+
+        {!cancelAtPeriodEnd && (
+          <Dialog
+            open={isCancelDialogOpen}
+            onOpenChange={setIsCancelDialogOpen}
+          >
+            <DialogTrigger asChild>
+              <Button variant="destructive" size="lg">
+                サブスクリプションを解約
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>本当に解約しますか？</DialogTitle>
+                <DialogDescription className="pt-2">
+                  サブスクリプションを解約すると、現在の請求期間の終了後、Proの機能が利用できなくなります。この操作は元に戻せません。
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setIsCancelDialogOpen(false)}
+                  disabled={mutation.isPending}
+                >
+                  キャンセル
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={() => mutation.mutate()}
+                  disabled={mutation.isPending}
+                >
+                  {mutation.isPending && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  解約を予約する
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/front/components/UpgradeButton.tsx
+++ b/front/components/UpgradeButton.tsx
@@ -16,7 +16,8 @@ const calculateRemainingDays = (endDate: Date | null): number => {
 };
 
 export const UpgradeButton = () => {
-  const { status, subscriptionEndDate, isLoading } = useUserStatus();
+  const { status, subscriptionEndDate, isLoading, cancelAtPeriodEnd } =
+    useUserStatus();
 
   if (isLoading) {
     return (
@@ -45,7 +46,13 @@ export const UpgradeButton = () => {
             <Crown className="mr-2 h-4 w-4 text-yellow-500" /> Pro{" "}
             <span className="text-xs ml-1">(Sub)</span>
           </div>
-          <div className="text-xs mt-0.5">残り {remainingDays} 日</div>
+          {cancelAtPeriodEnd ? (
+            <div className="text-xs mt-0.5 text-destructive-foreground">
+              解約予約済み
+            </div>
+          ) : (
+            <div className="text-xs mt-0.5">残り {remainingDays} 日</div>
+          )}
         </Link>
       </Button>
     );

--- a/front/hooks/useUserStatus.ts
+++ b/front/hooks/useUserStatus.ts
@@ -11,13 +11,18 @@ import { API_URL } from "@/constants/config";
 type UserStatusResponse = {
   status: "none" | "subscribed" | "lifetime";
   subscription_end_date?: string;
+  cancel_at_period_end?: boolean;
 };
 
 // ユーザーのプレミアム状態を取得するAPI関数
 const fetchUserStatus = async (getToken: () => Promise<string | null>) => {
   const token = await getToken();
   if (!token) {
-    return { status: "none", subscription_end_date: undefined };
+    return {
+      status: "none",
+      subscription_end_date: undefined,
+      cancel_at_period_end: false,
+    };
   }
 
   const { data } = await axios.get<UserStatusResponse>(
@@ -50,5 +55,6 @@ export const useUserStatus = () => {
     isLoading,
     error,
     isPremium: data?.status === "lifetime" || data?.status === "subscribed",
+    cancelAtPeriodEnd: data?.cancel_at_period_end ?? false,
   };
 };


### PR DESCRIPTION
## 【概要】
サブスクプランのキャンセル予約処理の実装

## 【目的】
サブスク加入後、キャンセルする手段がなかったためキャンセル機能を実装
キャンセル実行後、即サービスを利用できなくなるのは問題なため、期限終了日にキャンセルされるよう実装

## 【大事なこと】
- PythonのSDKでキャンセル予約を行う際は`stripe.Subscription.modify()`を使用する(※update()ではない)
```
stripe.Subscription.modify(
            {{subscription_id}},
            cancel_at_period_end=True,
        )
```

## 【修正内容】
### バックエンド
- キャンセル予約済みか否かを判断するステータス値を追加
- サブスクリプションをキャンセルするエンドポイントを追加
- サブスクプランから買い切りプランへ移行した場合も、サブスクをキャンセルする処理を追加
- [概要と関係のない処理]
  - 買い切りプランユーザーの場合、Stripeの`Customer_id`が設定されていなかったため設定されるように修正

### フロント
- ユーザーのプラン状況が「サブスクプラン」の際にサブスクのキャンセルを行う選択肢を追加
- ステータス状況が複雑になってきていたため、JSX部分で条件分岐を行わずコード部分で状況判断を行うよう修正
- サブスクキャンセルの画面を新規作成(`SubscribedView.tsx`)
- アップグレードボタンに「(サブスク)解約予約済み」の表示を追加