### PR TITLE
[fix] 成功ページの再表示バグの修正

### DIFF
--- a/front/app/@modal/(.)upgrade/success/page.tsx
+++ b/front/app/@modal/(.)upgrade/success/page.tsx
@@ -1,7 +1,7 @@
 // front/app/@modal/(.)upgrade/success/page.tsx
 "use client";
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { CheckCircle } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -17,6 +17,7 @@ const InterceptedSuccessPage = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(true);
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     // ユーザー情報を再取得してヘッダーの表示などを更新
@@ -35,6 +36,10 @@ const InterceptedSuccessPage = () => {
       }, 150);
     }
   }, [isOpen, router]);
+
+  if (searchParams.get("fromPayment") !== "true") {
+    return;
+  }
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>

--- a/front/components/CheckoutWrapper.tsx
+++ b/front/components/CheckoutWrapper.tsx
@@ -24,8 +24,6 @@ type Props = {
 
 export const CheckoutWrapper = ({ plan }: Props) => {
   const [clientSecret, setClientSecret] = useState<string | null>(null);
-  // 冪等性キー
-  const [idempotencyKey] = useState(() => uuidv4());
   const { getToken } = useAuth();
   const effectRan = useRef(false);
 
@@ -34,9 +32,15 @@ export const CheckoutWrapper = ({ plan }: Props) => {
       return;
     }
 
+    setClientSecret(null);
+    // 冪等性キー
+    const idempotencyKey = uuidv4();
+
     const createPaymentIntent = async () => {
       try {
         const token = await getToken();
+        if (!token) return;
+
         let response;
         if (plan === "subscription") {
           response = await axios.post(

--- a/front/components/PaymentForm.tsx
+++ b/front/components/PaymentForm.tsx
@@ -70,7 +70,7 @@ export const PaymentForm = ({ clientSecret }: PaymentFormProps) => {
       setIsLoading(false);
     } else if (paymentIntent && paymentIntent.status === "succeeded") {
       toast.success("アップグレードが完了しました！");
-      router.push("/upgrade/success");
+      router.push("/upgrade/success?fromPayment=true");
     }
   };
 


### PR DESCRIPTION
### 【概要】
成功ページの再表示バグの修正

### 【バグ詳細】
- 一度サブスクプランなどへ課金後、ページリロードを挟まず決算ページを開閉すると成功ページが表示されるバグが存在した
- Next.js の クライアントサイドルーティングにより前回の状態が残ってしまい、「再度アップグレードボタンを押す」＝「また success ページに遷移」扱いになり、モーダルだけが開いてしまっていたと推測する

### 【修正内容】
- 成功ページの表示をクエリパラメータで制御する
- クエリは毎回クリアされるため、直前で決算を行いクエリ付きの呼び出しを行わないと表示されない
- クエリパラメータ(`fromPayment`)が`true`の時のみ、成功ページのモーダルを表示するよう修正