### PR TITLE
[fix] ダークモード中のカード情報入力画面の文字色が背景色とほぼ同じだったため修正

### DIFF
--- a/front/app/@modal/(.)upgrade/page.tsx
+++ b/front/app/@modal/(.)upgrade/page.tsx
@@ -52,6 +52,11 @@ const InterceptedUpgradePage = () => {
             ? "p-0 border-0 bg-transparent shadow-none w-full max-w-md"
             : "w-full max-w-md"
         }
+        onPointerDownOutside={(e) => {
+          if (view === "payment") {
+            e.preventDefault();
+          }
+        }}
       >
         {isLoading && (
           <>

--- a/front/components/PaymentForm.tsx
+++ b/front/components/PaymentForm.tsx
@@ -1,7 +1,7 @@
 // front/components/PaymentForm.tsx
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -17,24 +17,10 @@ import { Button } from "@/components/ui/button";
 import { TestModeNotice } from "./TestModeNotice";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
+import { useTheme } from "next-themes";
 
 type PaymentFormProps = {
   clientSecret: string;
-};
-
-const elementOptions = {
-  style: {
-    base: {
-      fontSize: "16px",
-      color: "hsl(var(--foreground))",
-      "::placeholder": {
-        color: "hsl(var(--muted-foreground))",
-      },
-    },
-    invalid: {
-      color: "hsl(var(--destructive))",
-    },
-  },
 };
 
 export const PaymentForm = ({ clientSecret }: PaymentFormProps) => {
@@ -43,6 +29,7 @@ export const PaymentForm = ({ clientSecret }: PaymentFormProps) => {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [cardHolderName, setCardHolderName] = useState("");
+  const { resolvedTheme } = useTheme();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -74,6 +61,18 @@ export const PaymentForm = ({ clientSecret }: PaymentFormProps) => {
     }
   };
 
+  const options = useMemo(() => {
+    const isDark = resolvedTheme === "dark";
+    return {
+      style: {
+        base: {
+          color: isDark ? "#FFFFFF" : "#000000",
+        },
+        invalid: { color: "red" },
+      },
+    };
+  }, [resolvedTheme]);
+
   return (
     <div>
       <div className="flex justify-between items-center mb-6 text-left">
@@ -95,22 +94,22 @@ export const PaymentForm = ({ clientSecret }: PaymentFormProps) => {
 
         <div className="space-y-2">
           <Label htmlFor="card-number">カード番号</Label>
-          <div className="rounded-md border p-3">
-            <CardNumberElement id="card-number" options={elementOptions} />
+          <div className="rounded-md border p-3 bg-transparent dark:bg-input/30">
+            <CardNumberElement id="card-number" options={options} />
           </div>
         </div>
 
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2">
             <Label htmlFor="card-expiry">有効期限</Label>
-            <div className="rounded-md border p-3">
-              <CardExpiryElement id="card-expiry" options={elementOptions} />
+            <div className="rounded-md border p-3 bg-transparent dark:bg-input/30">
+              <CardExpiryElement id="card-expiry" options={options} />
             </div>
           </div>
           <div className="space-y-2">
             <Label htmlFor="card-cvc">セキュリティコード</Label>
-            <div className="rounded-md border p-3">
-              <CardCvcElement id="card-cvc" options={elementOptions} />
+            <div className="rounded-md border p-3 bg-transparent dark:bg-input/30">
+              <CardCvcElement id="card-cvc" options={options} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 【概要】
ダークモード中のカード情報入力画面の文字色が背景色とほぼ同じだったため修正
ついでに、カード情報入力画面は枠外をクリックしても閉じないように修正

## 【修正内容】
- 文字色・背景色が問題だった「カード番号」「有効期限」「セキュリティコード」のコンポーネントに、指定のスタイルを設定した`options`を渡すことで対応
- `CardElement`系の`iframe`へは`options.style`を渡すことで変更可能
- `StripeElements`に最適化された`appearance API`では変更できない

## 【スクリーンショット】
### 修正前
<img width="548" height="508" alt="スクリーンショット 2025-09-29 185526" src="https://github.com/user-attachments/assets/731bbb93-5105-42f4-80c9-d73772f42bc0" />

### 修正後
<img width="562" height="502" alt="image" src="https://github.com/user-attachments/assets/b55ca114-5c5e-4b16-a13b-bc336a0160e0" />

