### PR TITLE
[feature] ログアウト時にログインユーザーのレイアウトが残る状況を(クリアするように)修正

### DIFF
--- a/front/hooks/useLayout.ts
+++ b/front/hooks/useLayout.ts
@@ -54,6 +54,13 @@ export const useLayout = (defaultChartSizes: DefaultChartSizes) => {
     }
   }, [initialLayouts]);
 
+  useEffect(() => {
+    if (!isSignedIn) {
+      setLayouts({});
+      isInitialLoad.current = true;
+    }
+  }, [isSignedIn]);
+
   const mutation = useMutation({
     mutationFn: saveLayoutApi,
     onSuccess: (_, savedLayouts) => {


### PR DESCRIPTION
### 【概要】
ログアウト時にログインユーザーのレイアウトが残っていたためこれをクリアするように修正

### 【修正内容】
- ログイン状態を`useEffect`で監視し、ログアウト時にはレイアウトをクリアするように修正